### PR TITLE
feat(infra): sandbox SSH para probar el asistente IA sin VPS externo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,16 @@ OPENROUTER_API_KEY=sk-or-v1-tu-clave-aqui
 # fiable). Los modelos `:free` tienen rate limits estrictos.
 OPENROUTER_MODEL=openai/gpt-4o-mini
 
+# ===== Sandbox SSH (servicio sandbox-ssh del docker-compose) =====
+
+# Clave pública SSH que se instalará en /home/demo/.ssh/authorized_keys del
+# contenedor sandbox-ssh. Solo se acepta autenticación por clave (sin password).
+# El SSH del contenedor escucha en 2222 y se publica en el puerto 2222 del host,
+# así que desde la app se configura como: host = dominio del VPS, puerto = 2222,
+# usuario = demo, clave privada = la pareja de esta pública.
+# Generala con: ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519_autodeploy_sandbox -N ""
+SANDBOX_PUBLIC_KEY=ssh-ed25519 AAAA... autodeploy-sandbox-demo
+
 # ===== Puerto del host (VPS) =====
 
 # Puerto del host donde se publica el frontend nginx del contenedor.

--- a/autodeploy/src/app/services/idioma.service.spec.ts
+++ b/autodeploy/src/app/services/idioma.service.spec.ts
@@ -1,0 +1,132 @@
+import { TestBed } from "@angular/core/testing";
+import { HttpTestingController, provideHttpClientTesting } from "@angular/common/http/testing";
+import { provideHttpClient } from "@angular/common/http";
+import { TranslateModule, TranslateService } from "@ngx-translate/core";
+import { IdiomaService } from "./idioma.service";
+
+describe("IdiomaService", function() {
+  let servicio: IdiomaService;
+  let translate: TranslateService;
+  let httpTest: HttpTestingController;
+  const CLAVE_LOCAL = "autodeploy_idioma";
+
+  beforeEach(function() {
+    localStorage.clear();
+    sessionStorage.clear();
+
+    TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        IdiomaService
+      ]
+    });
+
+    servicio = TestBed.inject(IdiomaService);
+    translate = TestBed.inject(TranslateService);
+    httpTest = TestBed.inject(HttpTestingController);
+
+    spyOn(translate, "use").and.callThrough();
+  });
+
+  afterEach(function() {
+    httpTest.verify();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it("inicializar usa el idioma guardado en localStorage si es válido", function() {
+    localStorage.setItem(CLAVE_LOCAL, "fr");
+
+    servicio.inicializar();
+
+    expect(servicio.idiomaActual()).toBe("fr");
+    expect(translate.use).toHaveBeenCalledWith("fr");
+  });
+
+  it("inicializar cae al idioma del navegador cuando no hay localStorage", function() {
+    const navegadorMock = spyOnProperty(navigator, "language", "get").and.returnValue("de-DE");
+
+    servicio.inicializar();
+
+    expect(servicio.idiomaActual()).toBe("de");
+    expect(translate.use).toHaveBeenCalledWith("de");
+    expect(navegadorMock).toHaveBeenCalled();
+  });
+
+  it("inicializar cae a 'es' cuando el idioma del navegador no está soportado", function() {
+    spyOnProperty(navigator, "language", "get").and.returnValue("ja-JP");
+
+    servicio.inicializar();
+
+    expect(servicio.idiomaActual()).toBe("es");
+    expect(translate.use).toHaveBeenCalledWith("es");
+  });
+
+  it("cambiarIdioma a un idioma soportado lo aplica, persiste y sincroniza con backend", function() {
+    sessionStorage.setItem("usuarioId", "usuario-123");
+
+    servicio.cambiarIdioma("en");
+
+    expect(servicio.idiomaActual()).toBe("en");
+    expect(translate.use).toHaveBeenCalledWith("en");
+    expect(localStorage.getItem(CLAVE_LOCAL)).toBe("en");
+
+    const peticion = httpTest.expectOne("/api/usuarios/usuario-123/idioma");
+    expect(peticion.request.method).toBe("PUT");
+    expect(peticion.request.body).toEqual({ idioma: "en" });
+    peticion.flush({ success: true, message: "OK", data: {} });
+
+    expect(sessionStorage.getItem("idioma")).toBe("en");
+  });
+
+  it("cambiarIdioma con un código no soportado no aplica nada", function() {
+    servicio.cambiarIdioma("zz");
+
+    expect(servicio.idiomaActual()).toBe("es");
+    expect(translate.use).not.toHaveBeenCalled();
+    expect(localStorage.getItem(CLAVE_LOCAL)).toBeNull();
+    httpTest.expectNone("/api/usuarios/usuario-123/idioma");
+  });
+
+  it("cambiarIdioma sin usuarioId en sessionStorage no llama al backend", function() {
+    servicio.cambiarIdioma("it");
+
+    expect(servicio.idiomaActual()).toBe("it");
+    expect(localStorage.getItem(CLAVE_LOCAL)).toBe("it");
+    httpTest.expectNone(function(req) {
+      return req.url.includes("/idioma");
+    });
+  });
+
+  it("aplicarIdiomaDelUsuario aplica el idioma sin llamar al backend", function() {
+    sessionStorage.setItem("usuarioId", "usuario-456");
+
+    servicio.aplicarIdiomaDelUsuario("fr");
+
+    expect(servicio.idiomaActual()).toBe("fr");
+    expect(localStorage.getItem(CLAVE_LOCAL)).toBe("fr");
+    httpTest.expectNone(function(req) {
+      return req.url.includes("/idioma");
+    });
+  });
+
+  it("obtenerIdiomaSoportado devuelve el objeto cuando el código existe", function() {
+    const idioma = servicio.obtenerIdiomaSoportado("de");
+
+    expect(idioma).toBeDefined();
+    expect(idioma?.nombre).toBe("Deutsch");
+    expect(idioma?.bandera).toBe("DE");
+  });
+
+  it("obtenerIdiomaSoportado devuelve undefined cuando el código no existe", function() {
+    expect(servicio.obtenerIdiomaSoportado("pt")).toBeUndefined();
+  });
+
+  it("aplicar un idioma actualiza el atributo lang del documento", function() {
+    servicio.cambiarIdioma("it");
+
+    expect(document.documentElement.getAttribute("lang")).toBe("it");
+  });
+});

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -39,6 +39,30 @@ services:
       start_period: 60s
     restart: unless-stopped
 
+  # Contenedor sandbox para probar la conexión SSH del asistente IA sin tocar
+  # un VPS externo real. Sin sudo, claves SSH solamente, reseteable con
+  # `docker compose restart sandbox-ssh`. El SSH del contenedor escucha en 2222
+  # y se publica en el puerto 2222 del host, así desde la app se configura como
+  # un servidor más: host = autodeploy.kruhale.com, puerto = 2222, usuario = demo.
+  sandbox-ssh:
+    image: linuxserver/openssh-server:latest
+    container_name: autodeploy-sandbox
+    environment:
+      PUID: 1000
+      PGID: 1000
+      TZ: Europe/Madrid
+      USER_NAME: demo
+      PASSWORD_ACCESS: "false"
+      SUDO_ACCESS: "false"
+      PUBLIC_KEY: ${SANDBOX_PUBLIC_KEY}
+    volumes:
+      - sandbox-config:/config
+    ports:
+      - "2222:2222"
+    networks:
+      - red-interna
+    restart: unless-stopped
+
   frontend:
     image: ghcr.io/kruhale/autodeploy-frontend:${IMAGE_TAG:-latest}
     build: ./autodeploy
@@ -71,3 +95,4 @@ volumes:
   mongodb-datos:
   backend-logs:
   nginx-logs:
+  sandbox-config:


### PR DESCRIPTION
## Objetivo

Permitir probar el flujo completo del asistente IA en producción sin necesidad de un VPS externo real. Antes hacía falta un servidor SSH propio para configurarlo en la app y mandar el primer mensaje al chat.

## Cambios

- \`docker-compose.prod.yml\`: nuevo servicio \`sandbox-ssh\` basado en \`linuxserver/openssh-server\`. Usuario único \`demo\`, sin sudo, solo auth por clave SSH. Puerto interno 2222 publicado en el puerto 2222 del host.
- \`.env.example\`: documenta la nueva variable \`SANDBOX_PUBLIC_KEY\` y cómo generar la pareja localmente.

## Uso

Tras desplegar:
1. Añadir \`SANDBOX_PUBLIC_KEY\` al \`.env\` del VPS con la clave pública correspondiente.
2. Abrir puerto 2222 en el firewall del VPS.
3. Configurar en la app: host = dominio, puerto = 2222, usuario = demo, clave privada = la pareja local.

## Notas de seguridad

- Sin sudo: el usuario \`demo\` solo puede tocar su \`/home/demo\`.
- Volumen \`sandbox-config\` para mantener claves de host estables entre restarts.
- Conectado a \`red-interna\` por si en el futuro queremos conexión interna sin exponer al host.