### PR TITLE
fix(onboarding): añadir textarea para pegar la clave SSH privada

### DIFF
--- a/autodeploy/public/i18n/de.json
+++ b/autodeploy/public/i18n/de.json
@@ -711,7 +711,10 @@
       "authMethodKey": "SSH-Schlüssel",
       "contrasena": "Passwort",
       "authMethodContrasena": "Passwort",
-      "clavePlaceholder": "Geben Sie das Server-Passwort ein"
+      "clavePlaceholder": "Geben Sie das Server-Passwort ein",
+      "claveSsh": "Privater SSH-Schlüssel",
+      "claveSshPlaceholder": "-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----",
+      "claveSshPista": "Fügen Sie den vollständigen Inhalt Ihres privaten Schlüssels ein, einschließlich der Zeilen BEGIN und END."
     },
     "ayuda": {
       "titulo": "Brauchen Sie Hilfe?",

--- a/autodeploy/public/i18n/en.json
+++ b/autodeploy/public/i18n/en.json
@@ -711,7 +711,10 @@
       "authMethodKey": "SSH key",
       "contrasena": "Password",
       "authMethodContrasena": "Password",
-      "clavePlaceholder": "Enter the server password"
+      "clavePlaceholder": "Enter the server password",
+      "claveSsh": "SSH private key",
+      "claveSshPlaceholder": "-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----",
+      "claveSshPista": "Paste the full contents of your private key, including the BEGIN and END lines."
     },
     "ayuda": {
       "titulo": "Need help?",

--- a/autodeploy/public/i18n/es.json
+++ b/autodeploy/public/i18n/es.json
@@ -711,7 +711,10 @@
       "authMethodKey": "Clave SSH",
       "contrasena": "Contraseña",
       "authMethodContrasena": "Contraseña",
-      "clavePlaceholder": "Introduce la contraseña del servidor"
+      "clavePlaceholder": "Introduce la contraseña del servidor",
+      "claveSsh": "Clave SSH privada",
+      "claveSshPlaceholder": "-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----",
+      "claveSshPista": "Pega el contenido completo de tu clave privada, incluyendo las líneas BEGIN y END."
     },
     "ayuda": {
       "titulo": "¿Necesitas ayuda?",

--- a/autodeploy/public/i18n/fr.json
+++ b/autodeploy/public/i18n/fr.json
@@ -711,7 +711,10 @@
       "authMethodKey": "Clé SSH",
       "contrasena": "Mot de passe",
       "authMethodContrasena": "Mot de passe",
-      "clavePlaceholder": "Saisissez le mot de passe du serveur"
+      "clavePlaceholder": "Saisissez le mot de passe du serveur",
+      "claveSsh": "Clé SSH privée",
+      "claveSshPlaceholder": "-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----",
+      "claveSshPista": "Collez le contenu complet de votre clé privée, y compris les lignes BEGIN et END."
     },
     "ayuda": {
       "titulo": "Besoin d'aide ?",

--- a/autodeploy/public/i18n/it.json
+++ b/autodeploy/public/i18n/it.json
@@ -711,7 +711,10 @@
       "authMethodKey": "Chiave SSH",
       "contrasena": "Password",
       "authMethodContrasena": "Password",
-      "clavePlaceholder": "Inserisci la password del server"
+      "clavePlaceholder": "Inserisci la password del server",
+      "claveSsh": "Chiave SSH privata",
+      "claveSshPlaceholder": "-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----",
+      "claveSshPista": "Incolla l'intero contenuto della tua chiave privata, incluse le righe BEGIN e END."
     },
     "ayuda": {
       "titulo": "Hai bisogno di aiuto?",

--- a/autodeploy/src/app/pages/onboarding/onboarding.html
+++ b/autodeploy/src/app/pages/onboarding/onboarding.html
@@ -87,6 +87,13 @@
           <input class="campo__input" name="password" type="password" [placeholder]="'onboarding.formulario.clavePlaceholder' | translate" [ngModel]="passwordServidor()" (ngModelChange)="passwordServidor.set($event)">
         </section>
       }
+      @if (metodoAutenticacion() === 'key') {
+        <section class="campo">
+          <label class="campo__etiqueta">{{ "onboarding.formulario.claveSsh" | translate }}</label>
+          <textarea class="campo__textarea" name="claveSshPrivada" rows="8" spellcheck="false" autocomplete="off" [placeholder]="'onboarding.formulario.claveSshPlaceholder' | translate" [ngModel]="claveSshPrivada()" (ngModelChange)="claveSshPrivada.set($event)"></textarea>
+          <p class="campo__pista">{{ "onboarding.formulario.claveSshPista" | translate }}</p>
+        </section>
+      }
     </section>
   </section>
 

--- a/autodeploy/src/styles/03-elements/_forms.scss
+++ b/autodeploy/src/styles/03-elements/_forms.scss
@@ -63,6 +63,11 @@
   outline-offset: 2px;
 }
 
+.campo__pista {
+  font-size: var(--font-size-xs);
+  color: var(--texto-apagado);
+}
+
 .campo__select {
   padding: 0.625rem var(--spacing-size-l);
   background: rgba(240, 236, 226, 0.03);


### PR DESCRIPTION
## Bug

En \`/app/onboarding\` el toggle Clave SSH / Contraseña permitía elegir clave, pero no aparecía ningún input donde pegarla. Solo se renderizaba el input cuando se elegía Contraseña.

## Causa

El HTML solo tenía un bloque \`@if (metodoAutenticacion() === 'password')\`. Faltaba el equivalente para \`'key'\`. El binding \`claveSshPrivada\` ya existía en el TS, así que basta con añadir el textarea.

## Cambios

- \`onboarding.html\`: bloque \`@if === 'key'\` con un textarea de 8 filas, font-mono, placeholder OPENSSH y una nota de ayuda.
- \`_forms.scss\`: utilidad \`.campo__pista\` (texto fino bajo el campo).
- 5 archivos de \`i18n\` (es/en/fr/de/it): claves \`claveSsh\`, \`claveSshPlaceholder\`, \`claveSshPista\`.

## Verificación

- \`npm run build -- --configuration production\` ✅
- 68/68 tests Karma ✅