### PR TITLE
fix(onboarding): usar la clave i18n existente para Contraseña

### DIFF
--- a/autodeploy/src/app/pages/onboarding/onboarding.html
+++ b/autodeploy/src/app/pages/onboarding/onboarding.html
@@ -77,7 +77,7 @@
             <i class="fa-solid fa-key"></i> {{ "onboarding.formulario.authMethodKey" | translate }}
           </button>
           <button class="toggle__opcion" [class.toggle__opcion--activa]="metodoAutenticacion() === 'password'" (click)="cambiarMetodoAuth('password')">
-            <i class="fa-solid fa-lock"></i> {{ "onboarding.formulario.authMethodPassword" | translate }}
+            <i class="fa-solid fa-lock"></i> {{ "onboarding.formulario.authMethodContrasena" | translate }}
           </button>
         </section>
       </section>


### PR DESCRIPTION
El botón del toggle Clave SSH / Contraseña mostraba el literal `onboarding.formulario.authMethodPassword` porque esa clave no estaba traducida en ningún idioma. La buena es `authMethodContrasena`, que ya existía en los 5 archivos i18n. Una línea cambiada.