### PR TITLE
feat(backend): reconexión automática de servidores tras arrancar

### DIFF
--- a/autodeploy/src/app/pages/onboarding/onboarding.html
+++ b/autodeploy/src/app/pages/onboarding/onboarding.html
@@ -77,7 +77,7 @@
             <i class="fa-solid fa-key"></i> {{ "onboarding.formulario.authMethodKey" | translate }}
           </button>
           <button class="toggle__opcion" [class.toggle__opcion--activa]="metodoAutenticacion() === 'password'" (click)="cambiarMetodoAuth('password')">
-            <i class="fa-solid fa-lock"></i> {{ "onboarding.formulario.authMethodPassword" | translate }}
+            <i class="fa-solid fa-lock"></i> {{ "onboarding.formulario.authMethodContrasena" | translate }}
           </button>
         </section>
       </section>

--- a/backend/src/main/java/com/autodeploy/AutoDeployApplication.java
+++ b/backend/src/main/java/com/autodeploy/AutoDeployApplication.java
@@ -2,10 +2,12 @@ package com.autodeploy;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 public class AutoDeployApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/autodeploy/model/Servidor.java
+++ b/backend/src/main/java/com/autodeploy/model/Servidor.java
@@ -21,6 +21,7 @@ public class Servidor {
     private LocalDateTime fechaCreacion;
     private boolean backupsAutomaticosActivos = false;
     private String horaBackupAutomatico = "03:00";
+    private int fallosConsecutivosSsh = 0;
 
     public Servidor() {
         this.puertoSsh = 22;
@@ -30,7 +31,11 @@ public class Servidor {
         this.fechaCreacion = LocalDateTime.now();
         this.backupsAutomaticosActivos = false;
         this.horaBackupAutomatico = "03:00";
+        this.fallosConsecutivosSsh = 0;
     }
+
+    public int getFallosConsecutivosSsh() { return fallosConsecutivosSsh; }
+    public void setFallosConsecutivosSsh(int fallosConsecutivosSsh) { this.fallosConsecutivosSsh = fallosConsecutivosSsh; }
 
     public boolean isBackupsAutomaticosActivos() { return backupsAutomaticosActivos; }
     public void setBackupsAutomaticosActivos(boolean backupsAutomaticosActivos) { this.backupsAutomaticosActivos = backupsAutomaticosActivos; }

--- a/backend/src/main/java/com/autodeploy/service/MonitorMetricasService.java
+++ b/backend/src/main/java/com/autodeploy/service/MonitorMetricasService.java
@@ -32,16 +32,19 @@ public class MonitorMetricasService {
     private final MetricaServidorRepository metricaServidorRepository;
     private final GestorSesionesSshService gestorSesionesSshService;
     private final MetricasWebSocketHandler metricasWebSocketHandler;
+    private final ReconexionService reconexionService;
 
     public MonitorMetricasService(
             ServidorRepository servidorRepository,
             MetricaServidorRepository metricaServidorRepository,
             GestorSesionesSshService gestorSesionesSshService,
-            MetricasWebSocketHandler metricasWebSocketHandler) {
+            MetricasWebSocketHandler metricasWebSocketHandler,
+            ReconexionService reconexionService) {
         this.servidorRepository = servidorRepository;
         this.metricaServidorRepository = metricaServidorRepository;
         this.gestorSesionesSshService = gestorSesionesSshService;
         this.metricasWebSocketHandler = metricasWebSocketHandler;
+        this.reconexionService = reconexionService;
     }
 
     @Scheduled(fixedDelay = 30000, initialDelay = 10000)
@@ -60,15 +63,20 @@ public class MonitorMetricasService {
         MetricaServidor metricaResultado = new MetricaServidor();
         metricaResultado.setServidorId(servidor.getId());
 
+        boolean conexionFunciono;
         try {
             String salidaCruda = gestorSesionesSshService.ejecutar(servidor.getId(), COMANDO_RECOLECCION);
             rellenarDesdeSalida(metricaResultado, salidaCruda);
             metricaResultado.setSesionActiva(true);
+            conexionFunciono = true;
         } catch (Exception excepcionRecoleccion) {
             LOGGER.warn("No se pudo recolectar metricas de {} ({}): {}",
                     servidor.getNombre(), servidor.getDireccionIp(), excepcionRecoleccion.getMessage());
             metricaResultado.setSesionActiva(false);
+            conexionFunciono = false;
         }
+
+        reconexionService.anotarPing(servidor, conexionFunciono);
 
         MetricaServidor metricaGuardada = metricaServidorRepository.save(metricaResultado);
         metricasWebSocketHandler.difundirMetrica(metricaGuardada);

--- a/backend/src/main/java/com/autodeploy/service/ReconexionService.java
+++ b/backend/src/main/java/com/autodeploy/service/ReconexionService.java
@@ -1,0 +1,110 @@
+package com.autodeploy.service;
+
+import com.autodeploy.model.Servidor;
+import com.autodeploy.repository.ServidorRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Al arrancar el backend recorre todos los servidores guardados en BBDD,
+ * verifica conexión SSH a cada uno y actualiza Servidor.estado. Si el VPS
+ * tenía backups automáticos activos, además verifica que el cron sigue
+ * instalado en el VPS del usuario y lo reinstala si falta.
+ */
+@Service
+public class ReconexionService {
+
+    private static final Logger logger = LoggerFactory.getLogger(ReconexionService.class);
+    private static final String MARCA_CRON_BACKUP = "autodeploy-backup";
+
+    private final ServidorRepository servidorRepository;
+    private final SshCommandService sshCommandService;
+    private final BackupService backupService;
+
+    public ReconexionService(ServidorRepository servidorRepository,
+                             SshCommandService sshCommandService,
+                             BackupService backupService) {
+        this.servidorRepository = servidorRepository;
+        this.sshCommandService = sshCommandService;
+        this.backupService = backupService;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    @Async
+    public void reconectarTrasArranque() {
+        List<Servidor> listaServidores = servidorRepository.findAll();
+        logger.info("Reconexion al arrancar: {} servidores en BBDD", listaServidores.size());
+
+        for (Servidor servidor : listaServidores) {
+            refrescarEstado(servidor);
+            if (servidor.isBackupsAutomaticosActivos() && "conectado".equals(servidor.getEstado())) {
+                verificarCronDeBackup(servidor);
+            }
+        }
+
+        logger.info("Reconexion al arrancar completada");
+    }
+
+    /**
+     * Hace un ping SSH ejecutando `echo OK`. Actualiza estado y contador de
+     * fallos del servidor en BBDD. Devuelve true si la conexión fue OK.
+     */
+    public boolean refrescarEstado(Servidor servidor) {
+        try {
+            String salida = sshCommandService.ejecutarComando(servidor, "echo OK");
+            boolean responde = salida != null && salida.contains("OK");
+            anotarPing(servidor, responde);
+            return responde;
+        } catch (Exception excepcion) {
+            logger.warn("SSH ping fallido en servidor {} ({}): {}", servidor.getId(), servidor.getDireccionIp(), excepcion.getMessage());
+            anotarPing(servidor, false);
+            return false;
+        }
+    }
+
+    /**
+     * Punto de entrada reutilizable: aplica la regla de estado/fallos.
+     * Llamado tanto desde el job al arrancar como desde MonitorMetricasService
+     * tras cada ciclo de recolección.
+     *
+     * - Si el ping fue OK: estado="conectado", contador a 0.
+     * - Si falló: contador++. A partir del 3º fallo, estado="desconectado".
+     */
+    public void anotarPing(Servidor servidor, boolean conexionFunciono) {
+        if (conexionFunciono) {
+            servidor.setEstado("conectado");
+            servidor.setFallosConsecutivosSsh(0);
+        } else {
+            int nuevosFallos = servidor.getFallosConsecutivosSsh() + 1;
+            servidor.setFallosConsecutivosSsh(nuevosFallos);
+            if (nuevosFallos >= 3) {
+                servidor.setEstado("desconectado");
+            }
+        }
+        servidorRepository.save(servidor);
+    }
+
+    /**
+     * Comprueba si el cron de backup automático sigue en el crontab del VPS
+     * del usuario. Si no está, lo reinstala llamando a BackupService.
+     */
+    private void verificarCronDeBackup(Servidor servidor) {
+        try {
+            String crontabRemoto = sshCommandService.ejecutarComando(servidor, "crontab -l 2>/dev/null || true");
+            boolean cronPresente = crontabRemoto != null && crontabRemoto.contains(MARCA_CRON_BACKUP);
+
+            if (!cronPresente) {
+                logger.info("Cron de backup ausente en servidor {}: reinstalando", servidor.getId());
+                backupService.activarBackupsAutomaticos(servidor.getId(), servidor.getHoraBackupAutomatico());
+            }
+        } catch (Exception excepcion) {
+            logger.warn("No se pudo verificar el cron de backup en servidor {}: {}", servidor.getId(), excepcion.getMessage());
+        }
+    }
+}

--- a/backend/src/test/java/com/autodeploy/service/ReconexionServiceTest.java
+++ b/backend/src/test/java/com/autodeploy/service/ReconexionServiceTest.java
@@ -1,0 +1,122 @@
+package com.autodeploy.service;
+
+import com.autodeploy.model.Servidor;
+import com.autodeploy.repository.ServidorRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReconexionServiceTest {
+
+    @Mock
+    private ServidorRepository servidorRepository;
+
+    @Mock
+    private SshCommandService sshCommandService;
+
+    @Mock
+    private BackupService backupService;
+
+    @InjectMocks
+    private ReconexionService reconexionService;
+
+    private Servidor servidorPruebas;
+
+    @BeforeEach
+    void prepararServidorBase() {
+        servidorPruebas = new Servidor();
+        servidorPruebas.setId("srv-1");
+        servidorPruebas.setNombre("VPS de prueba");
+        servidorPruebas.setDireccionIp("203.0.113.10");
+        servidorPruebas.setEstado("pendiente");
+        servidorPruebas.setFallosConsecutivosSsh(0);
+        when(servidorRepository.save(any(Servidor.class))).thenAnswer(invocacion -> invocacion.getArgument(0));
+    }
+
+    @Test
+    @DisplayName("anotarPing: ping OK marca conectado y resetea fallos")
+    void anotarPing_deberiaMarcarConectadoYResetearFallos_cuandoConexionFunciona() {
+        servidorPruebas.setFallosConsecutivosSsh(2);
+        servidorPruebas.setEstado("pendiente");
+
+        reconexionService.anotarPing(servidorPruebas, true);
+
+        assertThat(servidorPruebas.getEstado()).isEqualTo("conectado");
+        assertThat(servidorPruebas.getFallosConsecutivosSsh()).isZero();
+        verify(servidorRepository).save(servidorPruebas);
+    }
+
+    @Test
+    @DisplayName("anotarPing: 1 fallo no cambia el estado")
+    void anotarPing_deberiaIncrementarFallos_sinCambiarEstado_paraPrimerFallo() {
+        servidorPruebas.setFallosConsecutivosSsh(0);
+        servidorPruebas.setEstado("conectado");
+
+        reconexionService.anotarPing(servidorPruebas, false);
+
+        assertThat(servidorPruebas.getFallosConsecutivosSsh()).isEqualTo(1);
+        assertThat(servidorPruebas.getEstado()).isEqualTo("conectado");
+        verify(servidorRepository).save(servidorPruebas);
+    }
+
+    @Test
+    @DisplayName("anotarPing: el tercer fallo consecutivo marca desconectado")
+    void anotarPing_deberiaMarcarDesconectado_alTercerFalloConsecutivo() {
+        servidorPruebas.setFallosConsecutivosSsh(2);
+        servidorPruebas.setEstado("conectado");
+
+        reconexionService.anotarPing(servidorPruebas, false);
+
+        assertThat(servidorPruebas.getFallosConsecutivosSsh()).isEqualTo(3);
+        assertThat(servidorPruebas.getEstado()).isEqualTo("desconectado");
+        verify(servidorRepository).save(servidorPruebas);
+    }
+
+    @Test
+    @DisplayName("anotarPing: ping OK tras varios fallos recupera el estado conectado")
+    void anotarPing_deberiaRecuperarse_cuandoVuelveAResponderTrasFallos() {
+        servidorPruebas.setFallosConsecutivosSsh(5);
+        servidorPruebas.setEstado("desconectado");
+
+        reconexionService.anotarPing(servidorPruebas, true);
+
+        assertThat(servidorPruebas.getEstado()).isEqualTo("conectado");
+        assertThat(servidorPruebas.getFallosConsecutivosSsh()).isZero();
+    }
+
+    @Test
+    @DisplayName("refrescarEstado: salida con OK marca conectado")
+    void refrescarEstado_deberiaMarcarConectado_cuandoSshDevuelveOk() {
+        when(sshCommandService.ejecutarComando(servidorPruebas, "echo OK")).thenReturn("OK\n");
+
+        boolean resultado = reconexionService.refrescarEstado(servidorPruebas);
+
+        assertThat(resultado).isTrue();
+        assertThat(servidorPruebas.getEstado()).isEqualTo("conectado");
+        assertThat(servidorPruebas.getFallosConsecutivosSsh()).isZero();
+    }
+
+    @Test
+    @DisplayName("refrescarEstado: excepción SSH no rethrows y cuenta como fallo")
+    void refrescarEstado_deberiaContarComoFallo_cuandoSshLanzaExcepcion() {
+        when(sshCommandService.ejecutarComando(servidorPruebas, "echo OK"))
+                .thenThrow(new RuntimeException("connection refused"));
+
+        boolean resultado = reconexionService.refrescarEstado(servidorPruebas);
+
+        assertThat(resultado).isFalse();
+        assertThat(servidorPruebas.getFallosConsecutivosSsh()).isEqualTo(1);
+        verify(backupService, never()).activarBackupsAutomaticos(any(), any());
+    }
+}


### PR DESCRIPTION
## Problema

Cuando el VPS donde corre AutoDeploy se reinicia, el campo \`Servidor.estado\` en MongoDB queda con el último valor escrito antes del corte (que ya no refleja la realidad), y los crons de backup que AutoDeploy instaló en los VPS de los usuarios podrían haber sido borrados durante la caída. Hasta ahora no había nada que reconciliara el estado al volver.

## Cambios

### Modelo
- \`Servidor.java\`: nuevo campo \`fallosConsecutivosSsh\` (int, default 0).

### Nuevo servicio
- \`ReconexionService.java\`:
  - \`@EventListener(ApplicationReadyEvent)\` + \`@Async\`: itera todos los servidores al arrancar, hace \`echo OK\` por SSH, actualiza estado.
  - Si \`backupsAutomaticosActivos\` y estado conectado, verifica que el cron sigue en \`crontab -l\` (busca la marca \`autodeploy-backup\`) y lo reinstala con \`BackupService.activarBackupsAutomaticos\` si falta. Idempotente: el método remoto ya hace \`grep -v\` antes de añadir.

### Reutilización en el monitor
- \`MonitorMetricasService.java\`: tras cada \`recolectarParaServidor\` llama a \`reconexionService.anotarPing(servidor, conexionFunciono)\`. Mismo tratamiento al polling cada 30 s.

### Habilitar async
- \`AutoDeployApplication.java\`: \`@EnableAsync\` (sin esto el job no se ejecuta en otro hilo).

## Regla de estado (en \`anotarPing\`)

| Resultado del ping | Acción |
|--------------------|--------|
| OK | estado = "conectado", fallos = 0 |
| KO | fallos++ ; al 3º fallo, estado = "desconectado" |

Esto se cubre con 6 tests Mockito en \`ReconexionServiceTest\`.

## Verificación tras desplegar

1. Apagar el sandbox: \`docker compose stop sandbox-ssh\` en el VPS.
2. Esperar ~90 s (3 ciclos del monitor a 30 s).
3. Comprobar que el servidor "sandbox" pasa a \`estado=desconectado\` en MongoDB.
4. \`docker compose start sandbox-ssh\`. Esperar 30 s.
5. Comprobar que vuelve a \`estado=conectado\` y \`fallosConsecutivosSsh=0\`.

## Lo que NO incluye

- Notificación al usuario cuando un servidor se desconecta: el modelo \`Servidor\` no guarda \`usuarioId\` (deuda preexistente). Cuando se arregle eso, basta con añadir una llamada a \`notificacionService.crearNotificacion\` en \`anotarPing\`.