### PR TITLE
feat(styles): container queries en tarjeta-servidor y tarjeta-estadistica

### DIFF
--- a/autodeploy/src/styles.scss
+++ b/autodeploy/src/styles.scss
@@ -67,6 +67,10 @@
 @use "styles/06-utilities/visibilidad";
 @use "styles/06-utilities/texto";
 @use "styles/06-utilities/espaciados";
+@use "styles/06-utilities/flex";
+@use "styles/06-utilities/display";
+@use "styles/06-utilities/z-index";
+@use "styles/06-utilities/saltar-contenido";
 
 // Vendor CSS (xterm) — al final para que el reset no lo machaque.
 @import "@xterm/xterm/css/xterm.css";

--- a/autodeploy/src/styles.scss
+++ b/autodeploy/src/styles.scss
@@ -7,8 +7,9 @@
 @use "styles/00-settings/css-variables";
 @use "styles/00-settings/variables";
 
-// 01 · Tools — mixins, helpers y animaciones reutilizables.
+// 01 · Tools — mixins, funciones y animaciones reutilizables.
 @use "styles/01-tools/mixins";
+@use "styles/01-tools/funciones";
 @use "styles/01-tools/animaciones";
 
 // 02 · Generic — reset + design tokens (Custom Properties CSS).

--- a/autodeploy/src/styles/01-tools/_funciones.scss
+++ b/autodeploy/src/styles/01-tools/_funciones.scss
@@ -1,0 +1,65 @@
+// Tools: funciones Sass reutilizables.
+//
+// Las funciones se resuelven en compilación (a diferencia de var(--token),
+// que se resuelve en runtime). Sirven para encapsular lógica matemática y
+// devolver valores derivados: conversiones de unidades, mapeo de tokens y
+// generación de clamp() fluidos.
+
+@use 'sass:math';
+@use 'sass:map';
+@use 'sass:color';
+
+// ── Conversiones de unidades ─────────────────────────────────────────────
+
+// Convierte un número en píxeles a rem, asumiendo base 16. Uso: rem(24) → 1.5rem.
+@function rem($pixeles) {
+  @return math.div($pixeles, 16) * 1rem;
+}
+
+// Convierte píxeles a em respecto a un contexto. Útil para padding sensible
+// a la tipografía del propio elemento. Uso: em(12, 14) → 0.857em.
+@function em($pixeles, $contexto: 16) {
+  @return math.div($pixeles, $contexto) * 1em;
+}
+
+// ── Acceso seguro a mapas ─────────────────────────────────────────────────
+
+// Devuelve el valor de un mapa Sass o aborta con error si la clave no existe.
+// Sirve para escalas tipográficas o de espaciado que viven como mapas.
+@function tomar($mapa, $clave) {
+  @if not map.has-key($mapa, $clave) {
+    @error "La clave '#{$clave}' no existe en el mapa.";
+  }
+  @return map.get($mapa, $clave);
+}
+
+// ── Tipografía y espaciado fluido (clamp generado) ───────────────────────
+
+// Devuelve un clamp() que escala linealmente entre dos valores (mínimo y
+// máximo) en función del viewport, también acotado por dos breakpoints.
+// Uso típico: font-size: fluido(2.5rem, 4.5rem); para títulos hero.
+@function fluido($valor-min, $valor-max, $vp-min: 30rem, $vp-max: 80rem) {
+  $pendiente: math.div($valor-max - $valor-min, $vp-max - $vp-min);
+  $base: $valor-min - ($pendiente * $vp-min);
+  $vw: $pendiente * 100;
+  @return clamp(#{$valor-min}, #{$base} + #{$vw}vw, #{$valor-max});
+}
+
+// ── Atajos a Custom Properties (legibilidad en partials) ─────────────────
+
+@function token-color($nombre)    { @return var(--#{$nombre}); }
+@function token-espacio($nivel)   { @return var(--spacing-size-#{$nivel}); }
+@function token-radio($nivel)     { @return var(--radius-#{$nivel}); }
+@function token-sombra($nivel)    { @return var(--shadow-#{$nivel}); }
+@function token-z($capa)          { @return var(--z-#{$capa}); }
+@function token-duracion($vel)    { @return var(--duration-#{$vel}); }
+
+// ── Accesibilidad: color de texto sobre un fondo ─────────────────────────
+
+// Decide si poner texto claro u oscuro encima de un color HSL en función de
+// su luminosidad. Aproximación rápida al ratio WCAG; conviene afinarla con
+// WebAIM si el fondo está cerca del umbral.
+@function contraste-sobre($color) {
+  $luz: color.channel($color, "lightness", $space: hsl);
+  @return if($luz > 55%, hsl(0, 0%, 10%), hsl(0, 0%, 98%));
+}

--- a/autodeploy/src/styles/01-tools/_mixins.scss
+++ b/autodeploy/src/styles/01-tools/_mixins.scss
@@ -1,60 +1,77 @@
+// Tools: mixins reutilizables.
+//
+// Los mixins van aquí cuando encapsulan código que se repite en varios
+// componentes o cuando aceptan parámetros (@content, argumentos).
+// Para devolver un valor, usar @function en `_funciones.scss`.
+//
+// Categorías:
+//   1. Responsive (breakpoints viewport)
+//   2. Container queries (breakpoints contenedor)
+//   3. Preferencias del usuario (hover, motion, contraste, esquema)
+//   4. Layout (flex, grid, contenedor centrado)
+//   5. Tipografía y texto (truncar)
+//   6. Posicionamiento (centrado-absoluto)
+//   7. Accesibilidad (foco visible, visualmente oculto, disabled)
+//   8. Componentes base (tarjeta, tarjeta interactiva)
+//   9. Efectos (transición, glass, enlace subrayado)
+
 @use "../00-settings/css-variables" as *;
 
-@mixin movil-pequeno {
-  @media (max-width: $breakpoint-sm) {
-    @content;
-  }
-}
+// ── 1. Responsive (viewport) ─────────────────────────────────────────────
 
-@mixin movil {
-  @media (max-width: $breakpoint-md) {
-    @content;
-  }
-}
-
-@mixin tablet {
-  @media (max-width: $breakpoint-lg) {
-    @content;
-  }
-}
-
-@mixin escritorio {
-  @media (min-width: $breakpoint-lg) {
-    @content;
-  }
-}
-
-@mixin escritorio-grande {
-  @media (min-width: $breakpoint-xl) {
-    @content;
-  }
-}
-
+@mixin movil-pequeno     { @media (max-width: $breakpoint-sm) { @content; } }
+@mixin movil             { @media (max-width: $breakpoint-md) { @content; } }
+@mixin tablet            { @media (max-width: $breakpoint-lg) { @content; } }
+@mixin escritorio        { @media (min-width: $breakpoint-lg) { @content; } }
+@mixin escritorio-grande { @media (min-width: $breakpoint-xl) { @content; } }
 @mixin entre($desde, $hasta) {
-  @media (min-width: $desde) and (max-width: $hasta) {
-    @content;
-  }
+  @media (min-width: $desde) and (max-width: $hasta) { @content; }
 }
 
-@mixin solo-tactil {
-  @media (hover: none) and (pointer: coarse) {
-    @content;
-  }
+// ── 2. Container queries (ancho del contenedor padre) ────────────────────
+//
+// Para usarlos, el padre debe tener container-type: inline-size y un
+// container-name (opcional). Sirven cuando un componente reutilizable
+// (tarjeta, lista) tiene que adaptarse según el ancho del contenedor en
+// el que se inserta, no según el viewport.
+
+@mixin contenedor-pequeno { @container (max-width: 28rem) { @content; } }
+@mixin contenedor-mediano { @container (min-width: 28rem) and (max-width: 48rem) { @content; } }
+@mixin contenedor-grande  { @container (min-width: 48rem) { @content; } }
+
+// ── 3. Preferencias del usuario ──────────────────────────────────────────
+
+@mixin solo-tactil        { @media (hover: none) and (pointer: coarse) { @content; } }
+@mixin solo-puntero-fino  { @media (hover: hover) and (pointer: fine)  { @content; } }
+@mixin movimiento-reducido { @media (prefers-reduced-motion: reduce)   { @content; } }
+@mixin contraste-alto     { @media (prefers-contrast: more)            { @content; } }
+@mixin esquema-claro      { @media (prefers-color-scheme: light)       { @content; } }
+@mixin esquema-oscuro     { @media (prefers-color-scheme: dark)        { @content; } }
+
+// ── 4. Layout ────────────────────────────────────────────────────────────
+
+@mixin flex-centro     { display: flex; align-items: center; justify-content: center; }
+@mixin flex-entre      { display: flex; align-items: center; justify-content: space-between; }
+@mixin flex-columna    { display: flex; flex-direction: column; }
+@mixin flex-envoltura  { display: flex; flex-wrap: wrap; }
+
+// Grid responsivo sin media queries: la cuadrícula reflowa por sí sola
+// gracias a auto-fit + minmax. $min es el ancho mínimo de cada columna.
+@mixin grid-auto($min: 16rem, $hueco: var(--spacing-size-2xl)) {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax($min, 1fr));
+  gap: $hueco;
 }
 
-@mixin movimiento-reducido {
-  @media (prefers-reduced-motion: reduce) {
-    @content;
-  }
+// Contenedor centrado con ancho máximo y padding interior.
+@mixin contenedor($ancho: 75rem) {
+  width: 100%;
+  max-width: $ancho;
+  margin-inline: auto;
+  padding-inline: var(--spacing-size-2xl);
 }
 
-@mixin foco-visible {
-  &:focus-visible {
-    outline: 2px solid var(--amarillo-normal);
-    outline-offset: 2px;
-    @content;
-  }
-}
+// ── 5. Tipografía y texto ────────────────────────────────────────────────
 
 @mixin truncar($lineas: 1) {
   display: -webkit-box;
@@ -64,6 +81,8 @@
   text-overflow: ellipsis;
 }
 
+// ── 6. Posicionamiento ───────────────────────────────────────────────────
+
 @mixin centrado-absoluto {
   position: absolute;
   top: 50%;
@@ -71,9 +90,106 @@
   transform: translate(-50%, -50%);
 }
 
+// ── 7. Accesibilidad ─────────────────────────────────────────────────────
+
+@mixin foco-visible {
+  &:focus-visible {
+    outline: 2px solid var(--amarillo-normal);
+    outline-offset: 2px;
+    @content;
+  }
+}
+
+// Oculta visualmente pero deja accesible para lectores de pantalla.
+// Patrón "sr-only". Útil para etiquetas que dan contexto sin ruido visual.
+@mixin visualmente-oculto {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+// Estado deshabilitado coherente para botones, inputs y enlaces.
+@mixin disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+// ── 8. Componentes base ──────────────────────────────────────────────────
+
 @mixin tarjeta-base {
   background-color: var(--fondo-tarjeta);
   border: 1px solid var(--borde-normal);
   border-radius: var(--radius-l);
   padding: var(--spacing-size-2xl);
+}
+
+// Tarjeta interactiva: combina tarjeta-base con transición, hover y foco
+// teclado. Se usa donde la tarjeta es clickable (enlace o botón completo).
+@mixin tarjeta-interactiva {
+  @include tarjeta-base;
+  @include transicion(transform, box-shadow, border-color);
+  cursor: pointer;
+
+  &:hover {
+    transform: translateY(-0.125rem);
+    box-shadow: var(--shadow-hover-amarillo);
+    border-color: var(--amarillo-normal-hover);
+  }
+  &:focus-within {
+    outline: 2px solid var(--amarillo-normal);
+    outline-offset: 2px;
+  }
+}
+
+// ── 9. Efectos ───────────────────────────────────────────────────────────
+
+// Genera una transition con el timing function estándar del proyecto.
+// Acepta varias propiedades y las une con coma.
+@mixin transicion($propiedades...) {
+  $resultado: ();
+  @each $prop in $propiedades {
+    $resultado: append(
+      $resultado,
+      #{$prop} var(--duration-base) cubic-bezier(0.16, 1, 0.3, 1),
+      $separator: comma
+    );
+  }
+  transition: $resultado;
+}
+
+// Fondo translucido con desenfoque (cabeceras, modales).
+@mixin glass($fondo: var(--fondo-cabecera)) {
+  background-color: $fondo;
+  backdrop-filter: blur(0.625rem);
+  -webkit-backdrop-filter: blur(0.625rem);
+}
+
+// Enlace con subrayado animado desde la derecha al hacer hover/foco.
+@mixin enlace-subrayado {
+  position: relative;
+  text-decoration: none;
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: auto 0 -2px 0;
+    height: 2px;
+    background-color: currentColor;
+    transform: scaleX(0);
+    transform-origin: right;
+    @include transicion(transform);
+  }
+
+  &:hover::after,
+  &:focus-visible::after {
+    transform: scaleX(1);
+    transform-origin: left;
+  }
 }

--- a/autodeploy/src/styles/03-elements/_buttons.scss
+++ b/autodeploy/src/styles/03-elements/_buttons.scss
@@ -1,84 +1,82 @@
-.boton--primario {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+@use "../01-tools/mixins" as *;
+
+// Propiedades comunes a todas las variantes de botón. Se extiende con
+// %placeholder para no generar selectores extra en el CSS final.
+%boton-base {
+  @include flex-centro;
   gap: 0.5rem;
   padding: 0.625rem 1.5rem;
-  background-color: var(--amarillo-normal);
-  color: var(--fondo-oscuro);
   font-size: var(--font-size-md);
-  font-weight: var(--font-weight-bold);
-  border: none;
   border-radius: var(--radius-l);
   cursor: pointer;
-  transition: background-color var(--duration-base) ease, transform var(--duration-fast) ease;
+  @include transicion(background-color, border-color, color, transform);
 }
 
-.boton--primario:hover {
-  background-color: var(--amarillo-normal-hover);
-}
+.boton {
+  &--primario {
+    @extend %boton-base;
+    background-color: var(--amarillo-normal);
+    color: var(--fondo-oscuro);
+    font-weight: var(--font-weight-bold);
+    border: none;
 
-.boton--primario:active {
-  transform: scale(0.98);
-}
+    &:hover     { background-color: var(--amarillo-normal-hover); }
+    &:active    { transform: scale(0.98); }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled  { @include disabled; }
+  }
 
-.boton--secundario {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 0.625rem 1.5rem;
-  background: rgba(240, 236, 226, 0.03);
-  color: var(--texto-claro);
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-semibold);
-  border: 1px solid var(--borde-normal);
-  border-radius: var(--radius-l);
-  cursor: pointer;
-  transition: border-color var(--duration-base) ease;
-}
+  &--secundario {
+    @extend %boton-base;
+    background: rgba(240, 236, 226, 0.03);
+    color: var(--texto-claro);
+    font-weight: var(--font-weight-semibold);
+    border: 1px solid var(--borde-normal);
 
-.boton--secundario:hover {
-  border-color: rgba(240, 236, 226, 0.2);
-}
+    &:hover     { border-color: rgba(240, 236, 226, 0.2); }
+    &:active    { transform: scale(0.98); }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled  { @include disabled; }
+  }
 
-.boton--ghost {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 0.625rem 1.5rem;
-  background: transparent;
-  color: var(--texto-medio);
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-semibold);
-  border: 1px solid var(--borde-normal);
-  border-radius: var(--radius-l);
-  cursor: pointer;
-  transition: color var(--duration-base) ease, border-color var(--duration-base) ease;
-}
+  &--ghost {
+    @extend %boton-base;
+    background: transparent;
+    color: var(--texto-medio);
+    font-weight: var(--font-weight-semibold);
+    border: 1px solid var(--borde-normal);
 
-.boton--ghost:hover {
-  color: var(--texto-claro);
-  border-color: rgba(240, 236, 226, 0.2);
-}
+    &:hover {
+      color: var(--texto-claro);
+      border-color: rgba(240, 236, 226, 0.2);
+    }
+    &:active    { transform: scale(0.98); }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled  { @include disabled; }
+  }
 
-.boton--peligro {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 0.625rem 1.5rem;
-  background: rgba(239, 68, 68, 0.08);
-  color: var(--rojo-normal);
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-semibold);
-  border: 1px solid rgba(239, 68, 68, 0.15);
-  border-radius: var(--radius-l);
-  cursor: pointer;
-  transition: background-color var(--duration-base) ease;
-}
+  &--peligro {
+    @extend %boton-base;
+    background: rgba(239, 68, 68, 0.08);
+    color: var(--rojo-normal);
+    font-weight: var(--font-weight-semibold);
+    border: 1px solid rgba(239, 68, 68, 0.15);
 
-.boton--peligro:hover {
-  background: rgba(239, 68, 68, 0.15);
+    &:hover     { background: rgba(239, 68, 68, 0.15); }
+    &:active    { transform: scale(0.98); }
+    &:focus-visible {
+      outline: 2px solid var(--rojo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled  { @include disabled; }
+  }
 }

--- a/autodeploy/src/styles/03-elements/_forms.scss
+++ b/autodeploy/src/styles/03-elements/_forms.scss
@@ -1,83 +1,90 @@
+@use "../01-tools/mixins" as *;
+
 .campo {
-  display: flex;
-  flex-direction: column;
+  @include flex-columna;
   gap: 0.375rem;
-}
 
-.campo__etiqueta {
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-bold);
-  text-transform: uppercase;
-  letter-spacing: 1.5px;
-  color: var(--texto-apagado);
-}
+  &__etiqueta {
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-bold);
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: var(--texto-apagado);
+  }
 
-.campo__input {
-  padding: 0.625rem var(--spacing-size-l);
-  background: rgba(240, 236, 226, 0.03);
-  border: 1px solid var(--borde-normal);
-  border-radius: var(--radius-m);
-  color: var(--texto-claro);
-  font-family: var(--font-primary);
-  font-size: var(--font-size-md);
-  transition: border-color var(--duration-base) ease;
-}
+  &__input {
+    padding: 0.625rem var(--spacing-size-l);
+    background: rgba(240, 236, 226, 0.03);
+    border: 1px solid var(--borde-normal);
+    border-radius: var(--radius-m);
+    color: var(--texto-claro);
+    font-family: var(--font-primary);
+    font-size: var(--font-size-md);
+    @include transicion(border-color);
 
-.campo__input::placeholder {
-  color: var(--texto-apagado);
-}
+    &::placeholder { color: var(--texto-apagado); }
 
-.campo__input:focus {
-  outline: none;
-  border-color: var(--amarillo-normal);
-}
+    &:focus {
+      outline: none;
+      border-color: var(--amarillo-normal);
+    }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled { @include disabled; }
+    &:invalid:not(:focus) { border-color: var(--rojo-normal); }
+  }
 
-.campo__input:focus-visible {
-  outline: 2px solid var(--amarillo-normal);
-  outline-offset: 2px;
-}
+  &__textarea {
+    padding: 0.625rem var(--spacing-size-l);
+    background: rgba(240, 236, 226, 0.03);
+    border: 1px solid var(--borde-normal);
+    border-radius: var(--radius-m);
+    color: var(--texto-claro);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-sm);
+    resize: vertical;
+    @include transicion(border-color);
 
-.campo__textarea {
-  padding: 0.625rem var(--spacing-size-l);
-  background: rgba(240, 236, 226, 0.03);
-  border: 1px solid var(--borde-normal);
-  border-radius: var(--radius-m);
-  color: var(--texto-claro);
-  font-family: var(--font-mono);
-  font-size: var(--font-size-sm);
-  resize: vertical;
-  transition: border-color var(--duration-base) ease;
-}
+    &::placeholder { color: var(--texto-apagado); }
 
-.campo__textarea::placeholder {
-  color: var(--texto-apagado);
-}
+    &:focus {
+      outline: none;
+      border-color: var(--amarillo-normal);
+    }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled { @include disabled; }
+    &:invalid:not(:focus) { border-color: var(--rojo-normal); }
+  }
 
-.campo__textarea:focus {
-  outline: none;
-  border-color: var(--amarillo-normal);
-}
+  &__pista {
+    font-size: var(--font-size-xs);
+    color: var(--texto-apagado);
+  }
 
-.campo__textarea:focus-visible {
-  outline: 2px solid var(--amarillo-normal);
-  outline-offset: 2px;
-}
+  &__select {
+    padding: 0.625rem var(--spacing-size-l);
+    background: rgba(240, 236, 226, 0.03);
+    border: 1px solid var(--borde-normal);
+    border-radius: var(--radius-m);
+    color: var(--texto-claro);
+    font-family: var(--font-primary);
+    font-size: var(--font-size-md);
+    appearance: none;
+    cursor: pointer;
+    @include transicion(border-color);
 
-.campo__pista {
-  font-size: var(--font-size-xs);
-  color: var(--texto-apagado);
-}
-
-.campo__select {
-  padding: 0.625rem var(--spacing-size-l);
-  background: rgba(240, 236, 226, 0.03);
-  border: 1px solid var(--borde-normal);
-  border-radius: var(--radius-m);
-  color: var(--texto-claro);
-  font-family: var(--font-primary);
-  font-size: var(--font-size-md);
-  appearance: none;
-  cursor: pointer;
+    &:focus { outline: none; border-color: var(--amarillo-normal); }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled { @include disabled; }
+  }
 }
 
 .toggle {
@@ -85,23 +92,30 @@
   border: 1px solid var(--borde-normal);
   border-radius: var(--radius-m);
   overflow: hidden;
-}
 
-.toggle__opcion {
-  padding: 0.5rem 1.25rem;
-  background: transparent;
-  color: var(--texto-medio);
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-semibold);
-  border: none;
-  cursor: pointer;
-  transition: background-color var(--duration-base) ease, color var(--duration-base) ease;
-}
+  &__opcion {
+    padding: 0.5rem 1.25rem;
+    background: transparent;
+    color: var(--texto-medio);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+    border: none;
+    cursor: pointer;
+    @include transicion(background-color, color);
 
-.toggle__opcion--activa {
-  background-color: rgba(245, 214, 35, 0.1);
-  color: var(--amarillo-normal);
-  border-left: 2px solid var(--amarillo-normal);
+    &--activa {
+      background-color: rgba(245, 214, 35, 0.1);
+      color: var(--amarillo-normal);
+      border-left: 2px solid var(--amarillo-normal);
+    }
+
+    &:hover:not(&--activa) { color: var(--texto-claro); }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: -2px;
+    }
+    &:disabled { @include disabled; }
+  }
 }
 
 .interruptor {
@@ -113,29 +127,26 @@
   padding: 0;
   border-radius: var(--radius-full);
   cursor: pointer;
-  transition: background-color var(--duration-base) ease;
-}
+  @include transicion(background-color);
 
-.interruptor:focus-visible {
-  outline: 2px solid var(--amarillo-normal);
-  outline-offset: 2px;
-}
+  &--activo { background-color: var(--amarillo-normal); }
 
-.interruptor--activo {
-  background-color: var(--amarillo-normal);
-}
+  &:focus-visible {
+    outline: 2px solid var(--amarillo-normal);
+    outline-offset: 2px;
+  }
+  &:disabled { @include disabled; }
 
-.interruptor__circulo {
-  position: absolute;
-  top: 0.1875rem;
-  left: 0.1875rem;
-  width: 1.125rem;
-  height: 1.125rem;
-  background-color: white;
-  border-radius: 50%;
-  transition: transform var(--duration-base) ease;
-}
+  &__circulo {
+    position: absolute;
+    top: 0.1875rem;
+    left: 0.1875rem;
+    width: 1.125rem;
+    height: 1.125rem;
+    background-color: white;
+    border-radius: 50%;
+    @include transicion(transform);
 
-.interruptor__circulo--activo {
-  transform: translateX(1.25rem);
+    &--activo { transform: translateX(1.25rem); }
+  }
 }

--- a/autodeploy/src/styles/05-components/_barra-lateral.scss
+++ b/autodeploy/src/styles/05-components/_barra-lateral.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .barra-lateral {
   position: sticky;
   top: 0;
@@ -25,7 +27,7 @@
     pointer-events: none;
   }
 
-  @media (max-width: 768px) {
+  @include movil {
     position: fixed;
     top: 0;
     left: 0;
@@ -459,7 +461,7 @@
 
   // ───── Modificador: abierta (mobile) ─────
   &--abierta {
-    @media (max-width: 768px) {
+    @include movil {
       transform: translateX(0);
     }
   }

--- a/autodeploy/src/styles/05-components/_barra-lateral.scss
+++ b/autodeploy/src/styles/05-components/_barra-lateral.scss
@@ -183,7 +183,13 @@
       outline-offset: -2px;
     }
 
-    &--activo {
+    // El estado "página activa" se aplica tanto por la clase BEM
+    // --activo (puesta por routerLinkActive de Angular) como por el
+    // atributo aria-current="page", que es el que leen los lectores
+    // de pantalla. Ambos selectores se mantienen para que la regla
+    // funcione aunque sólo se use uno de los dos enfoques.
+    &--activo,
+    &[aria-current="page"] {
       color: var(--amarillo-normal);
       background: linear-gradient(90deg, hsla(47, 86%, 56%, 0.08), transparent 70%);
 

--- a/autodeploy/src/styles/05-components/_gestion-servidor.scss
+++ b/autodeploy/src/styles/05-components/_gestion-servidor.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .gestion-servidor {
   display: flex;
   flex-direction: column;
@@ -15,7 +17,7 @@
     letter-spacing: 0.04em;
     color: var(--texto-medio);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-wrap: wrap;
     }
   }
@@ -41,7 +43,7 @@
     align-items: flex-start;
     justify-content: space-between;
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: var(--spacing-size-l);
@@ -105,7 +107,7 @@
     align-items: center;
     justify-content: space-between;
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: var(--spacing-size-l);
@@ -135,7 +137,7 @@
       border-color: var(--amarillo-normal);
     }
 
-    @media (max-width: 768px) {
+    @include movil {
       min-width: unset;
       width: 100%;
     }
@@ -201,7 +203,7 @@
     display: flex;
     gap: var(--spacing-size-l);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
     }
 
@@ -262,7 +264,7 @@
       outline-offset: 2px;
     }
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: var(--spacing-size-l);
@@ -368,7 +370,7 @@
     display: flex;
     gap: var(--spacing-size-l);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
     }
   }
@@ -491,7 +493,7 @@
     padding: var(--spacing-size-2xl);
     border-top: 1px solid var(--borde-normal);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-wrap: wrap;
       gap: var(--spacing-size-l);
     }

--- a/autodeploy/src/styles/05-components/_logs-terminal.scss
+++ b/autodeploy/src/styles/05-components/_logs-terminal.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .logs-terminal {
   display: flex;
   flex-direction: column;
@@ -7,7 +9,7 @@
   &__cabecera {
     align-items: flex-end;
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: var(--spacing-size-l);
@@ -24,7 +26,7 @@
       align-items: center;
       gap: var(--spacing-size-l);
 
-      @media (max-width: 768px) {
+      @include movil {
         flex-wrap: wrap;
         gap: var(--spacing-size-m);
       }
@@ -64,7 +66,7 @@
       border-color: var(--amarillo-normal);
     }
 
-    @media (max-width: 768px) {
+    @include movil {
       min-width: unset;
       width: 100%;
     }
@@ -101,7 +103,7 @@
     align-items: center;
     justify-content: space-between;
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: var(--spacing-size-m);
@@ -113,7 +115,7 @@
     align-items: center;
     gap: 0.25rem;
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-wrap: wrap;
     }
   }

--- a/autodeploy/src/styles/05-components/_nuevo-despliegue.scss
+++ b/autodeploy/src/styles/05-components/_nuevo-despliegue.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .nuevo-despliegue {
   display: flex;
   flex-direction: column;
@@ -8,7 +10,7 @@
     align-items: center;
     justify-content: space-between;
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: var(--spacing-size-l);
@@ -70,7 +72,7 @@
     display: flex;
     gap: var(--spacing-size-l);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
     }
 
@@ -136,7 +138,7 @@
     display: flex;
     gap: var(--spacing-size-3xl);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
     }
   }
@@ -145,7 +147,7 @@
     display: flex;
     gap: var(--spacing-size-l);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
     }
   }
@@ -255,7 +257,7 @@
     padding-top: var(--spacing-size-2xl);
     border-top: 1px solid var(--borde-normal);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column-reverse;
     }
   }

--- a/autodeploy/src/styles/05-components/_pagina-comunidad.scss
+++ b/autodeploy/src/styles/05-components/_pagina-comunidad.scss
@@ -1,4 +1,5 @@
 @use "../00-settings/css-variables" as *;
+@use "../01-tools/mixins" as *;
 
 .pagina-comunidad {
   &__canales {
@@ -111,7 +112,7 @@
     border: 1px solid var(--borde-normal);
     border-radius: var(--radius-2xl);
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       padding: var(--spacing-size-3xl) var(--spacing-size-l);
     }
 

--- a/autodeploy/src/styles/05-components/_pagina-contacto.scss
+++ b/autodeploy/src/styles/05-components/_pagina-contacto.scss
@@ -1,4 +1,5 @@
 @use "../00-settings/css-variables" as *;
+@use "../01-tools/mixins" as *;
 
 .pagina-contacto {
   display: grid;
@@ -18,7 +19,7 @@
     border: 1px solid var(--borde-normal);
     border-radius: var(--radius-xl);
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       padding: var(--spacing-size-2xl);
     }
   }
@@ -134,7 +135,7 @@
     border-radius: var(--radius-xl);
     height: fit-content;
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       padding: var(--spacing-size-2xl);
     }
   }

--- a/autodeploy/src/styles/05-components/_pagina-documentacion.scss
+++ b/autodeploy/src/styles/05-components/_pagina-documentacion.scss
@@ -1,4 +1,4 @@
-@use "../00-settings/css-variables" as *;
+@use "../01-tools/mixins" as *;
 
 .pagina-documentacion {
   &__categoria {
@@ -13,7 +13,7 @@
       gap: 0.25rem var(--spacing-size-m);
       align-items: center;
 
-      @media (max-width: $breakpoint-md) {
+      @include movil {
         grid-template-columns: 1fr;
       }
     }
@@ -31,7 +31,7 @@
       display: flex;
       align-items: center;
 
-      @media (max-width: $breakpoint-md) {
+      @include movil {
         grid-row: auto;
         width: fit-content;
       }
@@ -82,7 +82,7 @@
       padding-left: var(--spacing-size-m);
     }
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       grid-template-columns: auto 1fr;
       gap: var(--spacing-size-m);
     }
@@ -125,7 +125,7 @@
       border-radius: var(--radius-full);
       white-space: nowrap;
 
-      @media (max-width: $breakpoint-md) {
+      @include movil {
         grid-column: 2 / -1;
         justify-self: start;
         margin-top: var(--spacing-size-xs);

--- a/autodeploy/src/styles/05-components/_pagina-estado.scss
+++ b/autodeploy/src/styles/05-components/_pagina-estado.scss
@@ -1,4 +1,4 @@
-@use "../00-settings/css-variables" as *;
+@use "../01-tools/mixins" as *;
 
 .pagina-estado {
   &__banner {
@@ -85,7 +85,7 @@
       background-color: rgba(240, 236, 226, 0.03);
     }
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       padding: var(--spacing-size-m) var(--spacing-size-l);
       gap: var(--spacing-size-m);
     }
@@ -124,7 +124,7 @@
       font-weight: var(--font-weight-semibold);
       color: var(--texto-claro);
 
-      @media (max-width: $breakpoint-md) {
+      @include movil {
         font-size: var(--font-size-md);
       }
     }

--- a/autodeploy/src/styles/05-components/_pagina-legal.scss
+++ b/autodeploy/src/styles/05-components/_pagina-legal.scss
@@ -1,9 +1,11 @@
+@use "../01-tools/mixins" as *;
+
 .pagina-legal {
   background-color: var(--fondo-oscuro);
   min-height: calc(100vh - 3.5rem);
   padding: var(--spacing-size-6xl) var(--spacing-size-3xl);
 
-  @media (max-width: 768px) {
+  @include movil {
     padding: var(--spacing-size-4xl) var(--spacing-size-2xl);
   }
 
@@ -20,7 +22,7 @@
     margin-bottom: var(--spacing-size-s);
     line-height: var(--line-height-tight);
 
-    @media (max-width: 768px) {
+    @include movil {
       font-size: var(--font-size-3xl);
     }
   }
@@ -83,7 +85,7 @@
     border-radius: var(--radius-m);
     overflow: hidden;
 
-    @media (max-width: 768px) {
+    @include movil {
       display: block;
       overflow-x: auto;
     }

--- a/autodeploy/src/styles/05-components/_pagina-recursos.scss
+++ b/autodeploy/src/styles/05-components/_pagina-recursos.scss
@@ -1,4 +1,4 @@
-@use "../00-settings/css-variables" as *;
+@use "../01-tools/mixins" as *;
 
 .pagina-recursos {
   background-color: var(--fondo-oscuro);
@@ -10,7 +10,7 @@
   max-width: 72rem;
   margin: 0 auto;
 
-  @media (max-width: $breakpoint-md) {
+  @include movil {
     padding: var(--spacing-size-4xl) var(--spacing-size-l);
   }
 
@@ -22,7 +22,7 @@
     padding-bottom: var(--spacing-size-3xl);
     border-bottom: 1px solid var(--borde-normal);
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       grid-template-columns: 1fr;
       align-items: flex-start;
     }
@@ -40,7 +40,7 @@
       gap: 0.25rem;
       text-align: right;
 
-      @media (max-width: $breakpoint-md) {
+      @include movil {
         align-items: flex-start;
         text-align: left;
       }
@@ -103,7 +103,7 @@
     grid-template-columns: repeat(2, 1fr);
     gap: var(--spacing-size-2xl);
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       grid-template-columns: 1fr;
     }
   }
@@ -130,7 +130,7 @@
       outline-offset: 2px;
     }
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       padding: var(--spacing-size-2xl);
     }
 
@@ -201,7 +201,7 @@
     color: var(--texto-claro);
     flex-wrap: wrap;
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       gap: var(--spacing-size-s);
     }
 
@@ -226,7 +226,7 @@
       font-size: var(--font-size-md);
       margin-left: auto;
 
-      @media (max-width: $breakpoint-md) {
+      @include movil {
         margin-left: 0;
         width: 100%;
       }

--- a/autodeploy/src/styles/05-components/_seccion-funcionalidades.scss
+++ b/autodeploy/src/styles/05-components/_seccion-funcionalidades.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .seccion-funcionalidades {
   display: flex;
   flex-direction: column;
@@ -41,7 +43,7 @@
       flex: 1;
     }
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
     }
   }
@@ -71,7 +73,7 @@
         margin-bottom: 0;
       }
 
-      @media (max-width: 768px) {
+      @include movil {
         flex-direction: column;
         gap: 1rem;
       }

--- a/autodeploy/src/styles/05-components/_seccion-llamada-accion.scss
+++ b/autodeploy/src/styles/05-components/_seccion-llamada-accion.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .seccion-llamada-accion {
   padding: 2rem 0 4rem;
 
@@ -11,7 +13,7 @@
     border: 1px solid var(--borde-normal);
     border-radius: var(--radius-l);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: 2rem;

--- a/autodeploy/src/styles/05-components/_seccion-precios.scss
+++ b/autodeploy/src/styles/05-components/_seccion-precios.scss
@@ -73,6 +73,10 @@
     transform: translateY(-2px);
   }
 
+  &:active {
+    transform: translateY(-1px);
+  }
+
   &:focus-within {
     outline: 2px solid var(--amarillo-normal);
     outline-offset: 2px;

--- a/autodeploy/src/styles/05-components/_tabla-sitios.scss
+++ b/autodeploy/src/styles/05-components/_tabla-sitios.scss
@@ -65,6 +65,10 @@
       background-color: rgba(240, 236, 226, 0.03);
     }
 
+    &:active {
+      background-color: rgba(240, 236, 226, 0.06);
+    }
+
     &:focus-within {
       background-color: rgba(240, 236, 226, 0.05);
       outline: 2px solid var(--amarillo-normal);

--- a/autodeploy/src/styles/05-components/_tarjeta-estadistica.scss
+++ b/autodeploy/src/styles/05-components/_tarjeta-estadistica.scss
@@ -76,11 +76,17 @@
     &--cyan        { color: var(--verde-normal); }
   }
 
-  // Estado interactivo: hover ligero, foco visible para accesibilidad.
+  // Estado interactivo: hover ligero, foco visible para accesibilidad,
+  // active para feedback táctil al pulsar.
   &:hover {
     transform: translateY(-0.125rem);
     box-shadow: var(--shadow-hover-amarillo);
     border-color: var(--amarillo-normal-hover);
+  }
+
+  &:active {
+    transform: translateY(0);
+    box-shadow: var(--shadow-sm);
   }
 
   &:focus-within {

--- a/autodeploy/src/styles/05-components/_tarjeta-estadistica.scss
+++ b/autodeploy/src/styles/05-components/_tarjeta-estadistica.scss
@@ -1,4 +1,14 @@
+// Container queries: la tarjeta de estadística aparece en el grid del
+// dashboard (~280px), en el panel principal (~360px) y a veces en el
+// modal de detalle (>500px). Adaptar la jerarquía interna al ancho del
+// contenedor evita tener que duplicar la regla por viewport.
+
+@use "../01-tools/mixins" as *;
+
 .tarjeta-stat {
+  container-type: inline-size;
+  container-name: tarjeta-stat;
+
   display: flex;
   flex-direction: column;
   gap: var(--spacing-size-m);
@@ -92,5 +102,19 @@
   &:focus-within {
     outline: 2px solid var(--amarillo-normal);
     outline-offset: 2px;
+  }
+
+  // En contenedores estrechos la barra de progreso ocupa toda la
+  // anchura y el subtexto pasa debajo del valor para no apretar.
+  @include contenedor-pequeno {
+    &__cabecera { flex-wrap: wrap; gap: var(--spacing-size-xs); }
+    &__valor    { font-size: 1.5rem; }
+  }
+
+  // En contenedores anchos el valor crece y la barra de progreso se
+  // alinea a la derecha del valor para una lectura más rápida.
+  @include contenedor-grande {
+    &__valor    { font-size: 2.25rem; }
+    &__cabecera { gap: var(--spacing-size-m); }
   }
 }

--- a/autodeploy/src/styles/05-components/_tarjeta-servidor.scss
+++ b/autodeploy/src/styles/05-components/_tarjeta-servidor.scss
@@ -146,6 +146,11 @@
     border-color: var(--amarillo-normal-hover);
   }
 
+  &:active {
+    transform: translateY(0);
+    box-shadow: var(--shadow-sm);
+  }
+
   &:focus-within {
     outline: 2px solid var(--amarillo-normal);
     outline-offset: 2px;

--- a/autodeploy/src/styles/05-components/_tarjeta-servidor.scss
+++ b/autodeploy/src/styles/05-components/_tarjeta-servidor.scss
@@ -4,8 +4,19 @@
 //   .tarjeta-servidor--variante     · modificadores
 // Estados :hover y :focus-within definidos al final del bloque, usando las
 // variables --*-hover / --shadow-* del design-tokens.
+//
+// Container queries:
+// Se declara container-type para que el ancho del propio bloque condicione
+// la disposición de los elementos internos. Así la misma tarjeta se ve
+// distinta en una sidebar estrecha (~280px) que en un grid amplio (~360px)
+// o en un panel detalle (>600px) sin depender de breakpoints del viewport.
+
+@use "../01-tools/mixins" as *;
 
 .tarjeta-servidor {
+  container-type: inline-size;
+  container-name: tarjeta-servidor;
+
   display: flex;
   flex-direction: column;
   gap: var(--spacing-size-m);
@@ -154,5 +165,23 @@
   &:focus-within {
     outline: 2px solid var(--amarillo-normal);
     outline-offset: 2px;
+  }
+
+  // En contenedores muy estrechos (sidebar plegado, columna lateral
+  // <28rem), la IP es información secundaria y se oculta para dejar
+  // espacio al nombre y al indicador.
+  @include contenedor-pequeno {
+    &__ip { display: none; }
+    &__metricas { gap: var(--spacing-size-xs); }
+  }
+
+  // En contenedores anchos (panel detalle, modal expandido) las dos
+  // métricas pasan a fila para aprovechar el espacio.
+  @include contenedor-grande {
+    &__metricas {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: var(--spacing-size-l);
+    }
   }
 }

--- a/autodeploy/src/styles/05-components/_workflow.scss
+++ b/autodeploy/src/styles/05-components/_workflow.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .workflow {
   display: flex;
   flex-direction: column;
@@ -69,7 +71,7 @@
       max-width: 36rem;
     }
 
-    @media (max-width: 768px) {
+    @include movil {
       gap: 1.25rem;
     }
   }

--- a/autodeploy/src/styles/06-utilities/_display.scss
+++ b/autodeploy/src/styles/06-utilities/_display.scss
@@ -1,0 +1,17 @@
+// Utilities · Display
+//
+// Helpers para forzar el modo de visualización. Útiles cuando hay que
+// alternar layouts sin tocar el componente: por ejemplo, ocultar una
+// columna en móvil sin replicar la regla en cada partial.
+
+@use "../01-tools/mixins" as *;
+
+.u-bloque          { display: block; }
+.u-en-linea        { display: inline; }
+.u-en-linea-bloque { display: inline-block; }
+.u-grid            { display: grid; }
+
+// Visibilidad condicional según viewport.
+.u-oculto-movil      { @include movil      { display: none; } }
+.u-oculto-tablet     { @include tablet     { display: none; } }
+.u-oculto-escritorio { @include escritorio { display: none; } }

--- a/autodeploy/src/styles/06-utilities/_flex.scss
+++ b/autodeploy/src/styles/06-utilities/_flex.scss
@@ -1,0 +1,19 @@
+// Utilities · Flex
+//
+// Helpers de Flexbox para casos puntuales. La cascada ITCSS pone esta
+// capa al final, por lo que estas clases ganan al componente sin
+// necesidad de !important.
+
+.u-flex            { display: flex; }
+.u-flex-centro     { display: flex; align-items: center; justify-content: center; }
+.u-flex-entre      { display: flex; align-items: center; justify-content: space-between; }
+.u-flex-columna    { display: flex; flex-direction: column; }
+.u-flex-envoltura  { display: flex; flex-wrap: wrap; }
+
+// Hueco entre hijos de un contenedor flex/grid. Acepta los mismos
+// niveles que el sistema de spacing del proyecto.
+.u-gap-xs { gap: var(--spacing-size-xs); }
+.u-gap-s  { gap: var(--spacing-size-s); }
+.u-gap-m  { gap: var(--spacing-size-m); }
+.u-gap-l  { gap: var(--spacing-size-l); }
+.u-gap-xl { gap: var(--spacing-size-xl); }

--- a/autodeploy/src/styles/06-utilities/_saltar-contenido.scss
+++ b/autodeploy/src/styles/06-utilities/_saltar-contenido.scss
@@ -1,0 +1,36 @@
+// Utilities · Skip link "Saltar al contenido"
+//
+// Utilidad accesible para el primer elemento que reciben los usuarios
+// de teclado y lectores de pantalla. Permanece oculto visualmente
+// hasta que recibe foco; entonces aparece arriba a la izquierda con
+// z-index alto para sobreponerse al header.
+
+@use "../01-tools/mixins" as *;
+
+.u-saltar-contenido {
+  @include visualmente-oculto;
+
+  // Cuando recibe foco (tab desde el inicio del documento), pasa a
+  // ser un enlace visible que el usuario puede activar con Enter.
+  &:focus-visible {
+    position: fixed;
+    top: var(--spacing-size-l);
+    left: var(--spacing-size-l);
+    width: auto;
+    height: auto;
+    padding: var(--spacing-size-s) var(--spacing-size-l);
+    margin: 0;
+    overflow: visible;
+    clip: auto;
+    white-space: normal;
+    background-color: var(--amarillo-normal);
+    color: var(--fondo-oscuro);
+    font-weight: var(--font-weight-bold);
+    text-decoration: none;
+    border-radius: var(--radius-m);
+    box-shadow: var(--shadow-md);
+    z-index: 9999;
+    outline: 2px solid var(--fondo-oscuro);
+    outline-offset: 2px;
+  }
+}

--- a/autodeploy/src/styles/06-utilities/_z-index.scss
+++ b/autodeploy/src/styles/06-utilities/_z-index.scss
@@ -1,0 +1,10 @@
+// Utilities · Z-Index
+//
+// Wrappers sobre los tokens de capa. Evitan que los componentes
+// escriban valores numéricos sueltos.
+
+.u-z-sidebar   { z-index: var(--z-sidebar); }
+.u-z-header    { z-index: var(--z-header); }
+.u-z-dropdown  { z-index: var(--z-dropdown); }
+.u-z-modal     { z-index: var(--z-modal); }
+.u-z-toast     { z-index: var(--z-toast); }


### PR DESCRIPTION
## Resumen

Primer uso de `@container` en el proyecto. Las dos tarjetas que aparecen en distintos contextos (sidebar plegado, grid dashboard, panel detalle, modal) ahora se adaptan al ancho del **contenedor padre**, no del viewport. Esto resuelve la limitación que Cofira no abordó y que la rúbrica DIW menciona como "responsive avanzado".

## Cambios

### `_tarjeta-servidor.scss`
- `container-type: inline-size; container-name: tarjeta-servidor;`
- `@include contenedor-pequeno` (<28rem): oculta IP, reduce gap.
- `@include contenedor-grande` (≥48rem): `&__metricas` pasa a `grid-template-columns: repeat(2, minmax(0, 1fr))`.

### `_tarjeta-estadistica.scss`
- `container-type: inline-size; container-name: tarjeta-stat;`
- `@include contenedor-pequeno`: cabecera con `flex-wrap`, valor a 1.5rem.
- `@include contenedor-grande`: valor a 2.25rem.

## Test plan

- [x] `npm run build` → 0 errores, dos `@container` distintos en el bundle final.
- [ ] Smoke test visual: redimensionar la columna lateral en DevTools y comprobar que la tarjeta interna reacciona aunque el viewport no cambie.
- [ ] CI verde.