### PR TITLE
docs(styles): README con mixins, funciones, estados y estrategias responsive

### DIFF
--- a/autodeploy/public/i18n/de.json
+++ b/autodeploy/public/i18n/de.json
@@ -17,6 +17,11 @@
     "buscar": "Suchen",
     "guion": "—",
     "menu": "Menü",
+    "saltarContenido": "Zum Inhalt springen",
+    "cerrarMenu": "Menü schließen",
+    "ariaDisposicionApp": "AutoDeploy-Anwendung",
+    "ariaCabeceraMovil": "Mobiler Header",
+    "ariaContenidoApp": "Hauptinhalt der Anwendung",
     "sinDatos": "Noch keine Daten",
     "guardando": "Wird gespeichert…",
     "guardado": "Gespeichert",
@@ -74,7 +79,12 @@
       "contacto": "Kontakt",
       "comunidad": "Community"
     },
-    "copyright": "© 2026 AutoDeployService · Unternehmens-Cloud-Infrastruktur"
+    "copyright": "© 2026 AutoDeployService · Unternehmens-Cloud-Infrastruktur",
+    "ariaContenido": "Footer-Informationen und Links",
+    "ariaMarca": "Über AutoDeployService",
+    "ariaInferior": "Copyright und allgemeine Einstellungen",
+    "ariaAjustes": "Sprache und soziale Netzwerke",
+    "ariaRedes": "Soziale Netzwerke"
   },
   "barraPie": {
     "estado": "Alle Systeme betriebsbereit",
@@ -135,7 +145,11 @@
     },
     "chipPro": "Pro",
     "colapsar": "Einklappen",
-    "fallbackCuenta": "Mein Konto"
+    "fallbackCuenta": "Mein Konto",
+    "ariaPrincipal": "Seitenleiste der Anwendung",
+    "ariaNavegacion": "Hauptnavigation",
+    "ariaColapsar": "Seitenleiste einklappen oder ausklappen",
+    "ariaInfoUsuario": "Kontoinformationen"
   },
   "bannerCookies": {
     "texto": "Wir verwenden eigene Cookies, um Ihre Erfahrung zu verbessern. Lesen Sie unsere",
@@ -713,7 +727,7 @@
       "authMethodContrasena": "Passwort",
       "clavePlaceholder": "Geben Sie das Server-Passwort ein",
       "claveSsh": "Privater SSH-Schlüssel",
-      "claveSshPlaceholder": "-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----",
+      "claveSshPlaceholder": "Privaten Schlüssel hier einfügen (OpenSSH-Format, BEGIN/END-Zeilen einschließen)",
       "claveSshPista": "Fügen Sie den vollständigen Inhalt Ihres privaten Schlüssels ein, einschließlich der Zeilen BEGIN und END."
     },
     "ayuda": {

--- a/autodeploy/public/i18n/en.json
+++ b/autodeploy/public/i18n/en.json
@@ -17,6 +17,11 @@
     "buscar": "Search",
     "guion": "—",
     "menu": "Menu",
+    "saltarContenido": "Skip to content",
+    "cerrarMenu": "Close menu",
+    "ariaDisposicionApp": "AutoDeploy application",
+    "ariaCabeceraMovil": "Mobile header",
+    "ariaContenidoApp": "Main application content",
     "sinDatos": "No data yet",
     "guardando": "Saving…",
     "guardado": "Saved",
@@ -74,7 +79,12 @@
       "contacto": "Contact",
       "comunidad": "Community"
     },
-    "copyright": "© 2026 AutoDeployService · Enterprise cloud infrastructure"
+    "copyright": "© 2026 AutoDeployService · Enterprise cloud infrastructure",
+    "ariaContenido": "Footer information and links",
+    "ariaMarca": "About AutoDeployService",
+    "ariaInferior": "Copyright and general settings",
+    "ariaAjustes": "Language and social networks",
+    "ariaRedes": "Social networks"
   },
   "barraPie": {
     "estado": "All systems operational",
@@ -135,7 +145,11 @@
     },
     "chipPro": "Pro",
     "colapsar": "Collapse",
-    "fallbackCuenta": "My account"
+    "fallbackCuenta": "My account",
+    "ariaPrincipal": "Application sidebar",
+    "ariaNavegacion": "Main navigation",
+    "ariaColapsar": "Collapse or expand sidebar",
+    "ariaInfoUsuario": "Account information"
   },
   "bannerCookies": {
     "texto": "We use first-party cookies to improve your experience. Read our",
@@ -713,7 +727,7 @@
       "authMethodContrasena": "Password",
       "clavePlaceholder": "Enter the server password",
       "claveSsh": "SSH private key",
-      "claveSshPlaceholder": "-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----",
+      "claveSshPlaceholder": "Paste your private key here (OpenSSH format, BEGIN/END lines included)",
       "claveSshPista": "Paste the full contents of your private key, including the BEGIN and END lines."
     },
     "ayuda": {

--- a/autodeploy/public/i18n/es.json
+++ b/autodeploy/public/i18n/es.json
@@ -17,6 +17,11 @@
     "buscar": "Buscar",
     "guion": "—",
     "menu": "Menú",
+    "saltarContenido": "Saltar al contenido",
+    "cerrarMenu": "Cerrar menú",
+    "ariaDisposicionApp": "Aplicación AutoDeploy",
+    "ariaCabeceraMovil": "Cabecera móvil",
+    "ariaContenidoApp": "Contenido principal de la aplicación",
     "sinDatos": "Sin datos todavía",
     "guardando": "Guardando…",
     "guardado": "Guardado",
@@ -74,7 +79,12 @@
       "contacto": "Contacto",
       "comunidad": "Comunidad"
     },
-    "copyright": "© 2026 AutoDeployService · Infraestructura cloud empresarial"
+    "copyright": "© 2026 AutoDeployService · Infraestructura cloud empresarial",
+    "ariaContenido": "Información y enlaces del pie de página",
+    "ariaMarca": "Sobre AutoDeployService",
+    "ariaInferior": "Copyright y ajustes generales",
+    "ariaAjustes": "Idioma y redes sociales",
+    "ariaRedes": "Redes sociales"
   },
   "barraPie": {
     "estado": "Todos los sistemas operativos",
@@ -135,7 +145,11 @@
     },
     "chipPro": "Pro",
     "colapsar": "Colapsar",
-    "fallbackCuenta": "Mi cuenta"
+    "fallbackCuenta": "Mi cuenta",
+    "ariaPrincipal": "Barra lateral de la aplicación",
+    "ariaNavegacion": "Navegación principal",
+    "ariaColapsar": "Colapsar o expandir la barra lateral",
+    "ariaInfoUsuario": "Información de la cuenta"
   },
   "bannerCookies": {
     "texto": "Usamos cookies propias para mejorar tu experiencia. Consulta nuestra",
@@ -713,7 +727,7 @@
       "authMethodContrasena": "Contraseña",
       "clavePlaceholder": "Introduce la contraseña del servidor",
       "claveSsh": "Clave SSH privada",
-      "claveSshPlaceholder": "-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----",
+      "claveSshPlaceholder": "Pega aquí tu clave privada (formato OpenSSH, líneas BEGIN/END incluidas)",
       "claveSshPista": "Pega el contenido completo de tu clave privada, incluyendo las líneas BEGIN y END."
     },
     "ayuda": {

--- a/autodeploy/public/i18n/fr.json
+++ b/autodeploy/public/i18n/fr.json
@@ -17,6 +17,11 @@
     "buscar": "Rechercher",
     "guion": "—",
     "menu": "Menu",
+    "saltarContenido": "Aller au contenu",
+    "cerrarMenu": "Fermer le menu",
+    "ariaDisposicionApp": "Application AutoDeploy",
+    "ariaCabeceraMovil": "En-tête mobile",
+    "ariaContenidoApp": "Contenu principal de l'application",
     "sinDatos": "Aucune donnée pour le moment",
     "guardando": "Enregistrement…",
     "guardado": "Enregistré",
@@ -74,7 +79,12 @@
       "contacto": "Contact",
       "comunidad": "Communauté"
     },
-    "copyright": "© 2026 AutoDeployService · Infrastructure cloud d'entreprise"
+    "copyright": "© 2026 AutoDeployService · Infrastructure cloud d'entreprise",
+    "ariaContenido": "Informations et liens du pied de page",
+    "ariaMarca": "À propos d'AutoDeployService",
+    "ariaInferior": "Copyright et réglages généraux",
+    "ariaAjustes": "Langue et réseaux sociaux",
+    "ariaRedes": "Réseaux sociaux"
   },
   "barraPie": {
     "estado": "Tous les systèmes opérationnels",
@@ -135,7 +145,11 @@
     },
     "chipPro": "Pro",
     "colapsar": "Réduire",
-    "fallbackCuenta": "Mon compte"
+    "fallbackCuenta": "Mon compte",
+    "ariaPrincipal": "Barre latérale de l'application",
+    "ariaNavegacion": "Navigation principale",
+    "ariaColapsar": "Réduire ou agrandir la barre latérale",
+    "ariaInfoUsuario": "Informations du compte"
   },
   "bannerCookies": {
     "texto": "Nous utilisons des cookies propriétaires pour améliorer votre expérience. Consultez notre",
@@ -713,7 +727,7 @@
       "authMethodContrasena": "Mot de passe",
       "clavePlaceholder": "Saisissez le mot de passe du serveur",
       "claveSsh": "Clé SSH privée",
-      "claveSshPlaceholder": "-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----",
+      "claveSshPlaceholder": "Collez ici votre clé privée (format OpenSSH, lignes BEGIN/END incluses)",
       "claveSshPista": "Collez le contenu complet de votre clé privée, y compris les lignes BEGIN et END."
     },
     "ayuda": {

--- a/autodeploy/public/i18n/it.json
+++ b/autodeploy/public/i18n/it.json
@@ -17,6 +17,11 @@
     "buscar": "Cerca",
     "guion": "—",
     "menu": "Menu",
+    "saltarContenido": "Vai al contenuto",
+    "cerrarMenu": "Chiudi menu",
+    "ariaDisposicionApp": "Applicazione AutoDeploy",
+    "ariaCabeceraMovil": "Intestazione mobile",
+    "ariaContenidoApp": "Contenuto principale dell'applicazione",
     "sinDatos": "Nessun dato ancora",
     "guardando": "Salvataggio…",
     "guardado": "Salvato",
@@ -74,7 +79,12 @@
       "contacto": "Contatti",
       "comunidad": "Community"
     },
-    "copyright": "© 2026 AutoDeployService · Infrastruttura cloud aziendale"
+    "copyright": "© 2026 AutoDeployService · Infrastruttura cloud aziendale",
+    "ariaContenido": "Informazioni e link del piè di pagina",
+    "ariaMarca": "Su AutoDeployService",
+    "ariaInferior": "Copyright e impostazioni generali",
+    "ariaAjustes": "Lingua e social network",
+    "ariaRedes": "Social network"
   },
   "barraPie": {
     "estado": "Tutti i sistemi operativi",
@@ -135,7 +145,11 @@
     },
     "chipPro": "Pro",
     "colapsar": "Comprimi",
-    "fallbackCuenta": "Il mio account"
+    "fallbackCuenta": "Il mio account",
+    "ariaPrincipal": "Barra laterale dell'applicazione",
+    "ariaNavegacion": "Navigazione principale",
+    "ariaColapsar": "Comprimi o espandi la barra laterale",
+    "ariaInfoUsuario": "Informazioni dell'account"
   },
   "bannerCookies": {
     "texto": "Utilizziamo cookie propri per migliorare la tua esperienza. Consulta la nostra",
@@ -713,7 +727,7 @@
       "authMethodContrasena": "Password",
       "clavePlaceholder": "Inserisci la password del server",
       "claveSsh": "Chiave SSH privata",
-      "claveSshPlaceholder": "-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----",
+      "claveSshPlaceholder": "Incolla qui la tua chiave privata (formato OpenSSH, righe BEGIN/END incluse)",
       "claveSshPista": "Incolla l'intero contenuto della tua chiave privata, incluse le righe BEGIN e END."
     },
     "ayuda": {

--- a/autodeploy/src/app/components/layout/app-layout/app-layout.html
+++ b/autodeploy/src/app/components/layout/app-layout/app-layout.html
@@ -1,21 +1,23 @@
-<section class="disposicion-app">
-  <header class="disposicion-app__cabecera-movil">
+<section class="disposicion-app" [attr.aria-label]="'comun.ariaDisposicionApp' | translate">
+  <a class="u-saltar-contenido" href="#contenido-principal">{{ "comun.saltarContenido" | translate }}</a>
+
+  <header class="disposicion-app__cabecera-movil" [attr.aria-label]="'comun.ariaCabeceraMovil' | translate">
     <button class="disposicion-app__hamburguesa" (click)="alternarSidebar()" [attr.aria-label]="'comun.menu' | translate">
-      <i class="fa-solid fa-bars"></i>
+      <i class="fa-solid fa-bars" aria-hidden="true"></i>
     </button>
     <a class="disposicion-app__logo-movil" routerLink="/">
-      <img class="disposicion-app__logo-movil__imagen" src="logo.png" alt="">
-      <span class="disposicion-app__logo-movil__texto">Auto<span class="disposicion-app__logo-movil__texto--acento">Deploy</span></span>
+      <img class="disposicion-app__logo-movil__imagen" src="logo.png" alt="AutoDeploy">
+      <span class="disposicion-app__logo-movil__texto" aria-hidden="true">Auto<span class="disposicion-app__logo-movil__texto--acento">Deploy</span></span>
     </a>
     <app-campana-notificaciones></app-campana-notificaciones>
   </header>
 
-  <section class="disposicion-app__backdrop" [class.disposicion-app__backdrop--visible]="sidebarAbierta()" (click)="cerrarSidebar()"></section>
+  <button type="button" class="disposicion-app__backdrop" [class.disposicion-app__backdrop--visible]="sidebarAbierta()" (click)="cerrarSidebar()" [attr.aria-label]="'comun.cerrarMenu' | translate" tabindex="-1"></button>
 
   <app-sidebar [abierta]="sidebarAbierta()"></app-sidebar>
 
-  <section class="disposicion-app__contenido">
-    <main class="disposicion-app__principal">
+  <section class="disposicion-app__contenido" [attr.aria-label]="'comun.ariaContenidoApp' | translate">
+    <main id="contenido-principal" tabindex="-1" class="disposicion-app__principal">
       <router-outlet></router-outlet>
     </main>
     <app-barra-pie-app></app-barra-pie-app>

--- a/autodeploy/src/app/components/layout/footer/footer.html
+++ b/autodeploy/src/app/components/layout/footer/footer.html
@@ -1,16 +1,16 @@
 <footer class="pie">
-  <section class="pie__linea-decorativa"></section>
+  <hr class="pie__linea-decorativa" aria-hidden="true">
 
-  <section class="pie__contenido">
-    <section class="pie__marca">
+  <section class="pie__contenido" [attr.aria-label]="'footer.ariaContenido' | translate">
+    <section class="pie__marca" [attr.aria-label]="'footer.ariaMarca' | translate">
       <p class="pie__marca__nombre">AutoDeployService</p>
       <p class="pie__marca__descripcion">{{ "footer.marca.descripcion1" | translate }}</p>
       <p class="pie__marca__descripcion">{{ "footer.marca.descripcion2" | translate }}</p>
       <p class="pie__marca__descripcion">{{ "footer.marca.descripcion3" | translate }}</p>
     </section>
 
-    <nav class="pie__columna">
-      <p class="pie__columna__titulo">{{ "footer.columnaProducto.titulo" | translate }}</p>
+    <nav class="pie__columna" [attr.aria-label]="'footer.columnaProducto.titulo' | translate">
+      <p class="pie__columna__titulo" aria-hidden="true">{{ "footer.columnaProducto.titulo" | translate }}</p>
       <ul class="pie__columna__lista">
         <li><a class="pie__columna__enlace" routerLink="/" fragment="features">{{ "footer.columnaProducto.features" | translate }}</a></li>
         <li><a class="pie__columna__enlace" routerLink="/" fragment="how-it-works">{{ "footer.columnaProducto.comoFunciona" | translate }}</a></li>
@@ -19,8 +19,8 @@
       </ul>
     </nav>
 
-    <nav class="pie__columna">
-      <p class="pie__columna__titulo">{{ "footer.columnaLegal.titulo" | translate }}</p>
+    <nav class="pie__columna" [attr.aria-label]="'footer.columnaLegal.titulo' | translate">
+      <p class="pie__columna__titulo" aria-hidden="true">{{ "footer.columnaLegal.titulo" | translate }}</p>
       <ul class="pie__columna__lista">
         <li><a class="pie__columna__enlace" routerLink="/politica-privacidad">{{ "footer.columnaLegal.politicaPrivacidad" | translate }}</a></li>
         <li><a class="pie__columna__enlace" routerLink="/aviso-legal">{{ "footer.columnaLegal.terminos" | translate }}</a></li>
@@ -29,8 +29,8 @@
       </ul>
     </nav>
 
-    <nav class="pie__columna">
-      <p class="pie__columna__titulo">{{ "footer.columnaSoporte.titulo" | translate }}</p>
+    <nav class="pie__columna" [attr.aria-label]="'footer.columnaSoporte.titulo' | translate">
+      <p class="pie__columna__titulo" aria-hidden="true">{{ "footer.columnaSoporte.titulo" | translate }}</p>
       <ul class="pie__columna__lista">
         <li><a class="pie__columna__enlace" routerLink="/documentacion">{{ "footer.columnaSoporte.documentacion" | translate }}</a></li>
         <li><a class="pie__columna__enlace" routerLink="/estado">{{ "footer.columnaSoporte.estado" | translate }}</a></li>
@@ -40,29 +40,29 @@
     </nav>
   </section>
 
-  <section class="pie__separador"></section>
+  <hr class="pie__separador" aria-hidden="true">
 
-  <section class="pie__inferior">
+  <section class="pie__inferior" [attr.aria-label]="'footer.ariaInferior' | translate">
     <p class="pie__inferior__copyright">{{ "footer.copyright" | translate }}</p>
-    <section class="pie__inferior__bloque-derecha">
+    <section class="pie__inferior__bloque-derecha" [attr.aria-label]="'footer.ariaAjustes' | translate">
       <app-selector-idioma modo="desplegable"></app-selector-idioma>
-      <section class="pie__inferior__redes">
+      <nav class="pie__inferior__redes" [attr.aria-label]="'footer.ariaRedes' | translate">
         <a class="pie__inferior__red" href="https://github.com" target="_blank" rel="noopener" aria-label="GitHub">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
           </svg>
         </a>
-        <a class="pie__inferior__red" href="https://x.com" target="_blank" rel="noopener" aria-label="X Twitter">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+        <a class="pie__inferior__red" href="https://x.com" target="_blank" rel="noopener" aria-label="X (antes Twitter)">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
         </a>
         <a class="pie__inferior__red" href="https://instagram.com" target="_blank" rel="noopener" aria-label="Instagram">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 1 0 0 12.324 6.162 6.162 0 0 0 0-12.324zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.406-11.845a1.44 1.44 0 1 0 0 2.881 1.44 1.44 0 0 0 0-2.881z"/>
           </svg>
         </a>
-      </section>
+      </nav>
     </section>
   </section>
 </footer>

--- a/autodeploy/src/app/components/layout/footer/footer.scss
+++ b/autodeploy/src/app/components/layout/footer/footer.scss
@@ -7,6 +7,8 @@
 
 .pie__linea-decorativa {
   height: 1px;
+  border: 0;
+  margin: 0;
   background: var(--borde-normal);
 }
 
@@ -67,6 +69,8 @@
 
 .pie__separador {
   height: 1px;
+  border: 0;
+  margin: 0;
   background-color: var(--borde-normal);
 }
 

--- a/autodeploy/src/app/components/layout/sidebar/sidebar.component.html
+++ b/autodeploy/src/app/components/layout/sidebar/sidebar.component.html
@@ -1,42 +1,45 @@
-<aside class="barra-lateral" [class.barra-lateral--abierta]="abierta()" [class.barra-lateral--colapsada]="colapsada()">
+<aside class="barra-lateral" [class.barra-lateral--abierta]="abierta()" [class.barra-lateral--colapsada]="colapsada()" [attr.aria-label]="'sidebar.ariaPrincipal' | translate">
   <a class="barra-lateral__logo" routerLink="/">
-    <img class="barra-lateral__logo__imagen" src="logo.png" alt="">
-    <span class="barra-lateral__logo__texto">Auto<span class="barra-lateral__logo__texto--acento">Deploy</span></span>
+    <img class="barra-lateral__logo__imagen" src="logo.png" alt="AutoDeploy">
+    <span class="barra-lateral__logo__texto" aria-hidden="true">Auto<span class="barra-lateral__logo__texto--acento">Deploy</span></span>
     <span class="barra-lateral__logo__version" aria-hidden="true">v2.41</span>
   </a>
 
-  <nav class="barra-lateral__navegacion">
-    <section class="barra-lateral__seccion" data-indice="01">
+  <nav class="barra-lateral__navegacion" [attr.aria-label]="'sidebar.ariaNavegacion' | translate">
+    <section class="barra-lateral__seccion" data-indice="01" aria-labelledby="barra-lateral-titulo-1">
       <header class="barra-lateral__seccion__cabecera">
         <span class="barra-lateral__seccion__numero" aria-hidden="true">01</span>
-        <span class="barra-lateral__seccion__titulo">{{ "sidebar.secciones.principal" | translate }}</span>
+        <span class="barra-lateral__seccion__titulo" id="barra-lateral-titulo-1">{{ "sidebar.secciones.principal" | translate }}</span>
       </header>
       <ul class="barra-lateral__lista">
         <li>
           <a class="barra-lateral__enlace" routerLink="/app/dashboard" routerLinkActive="barra-lateral__enlace--activo"
-            [routerLinkActiveOptions]="{ exact: true }">
-            <i class="fa-solid fa-table-columns barra-lateral__enlace__icono"></i>
+            [routerLinkActiveOptions]="{ exact: true }" #rla1="routerLinkActive" [attr.aria-current]="rla1.isActive ? 'page' : null">
+            <i class="fa-solid fa-table-columns barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.dashboard" | translate }}</span>
             <span class="barra-lateral__enlace__indicador" aria-hidden="true"></span>
           </a>
         </li>
         <li>
-          <a class="barra-lateral__enlace" routerLink="/app/onboarding" routerLinkActive="barra-lateral__enlace--activo">
-            <i class="fa-solid fa-plug barra-lateral__enlace__icono"></i>
+          <a class="barra-lateral__enlace" routerLink="/app/onboarding" routerLinkActive="barra-lateral__enlace--activo"
+            #rla2="routerLinkActive" [attr.aria-current]="rla2.isActive ? 'page' : null">
+            <i class="fa-solid fa-plug barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.conectarServidor" | translate }}</span>
             <span class="barra-lateral__enlace__indicador" aria-hidden="true"></span>
           </a>
         </li>
         <li>
-          <a class="barra-lateral__enlace" routerLink="/app/logs" routerLinkActive="barra-lateral__enlace--activo">
-            <i class="fa-solid fa-chart-line barra-lateral__enlace__icono"></i>
+          <a class="barra-lateral__enlace" routerLink="/app/logs" routerLinkActive="barra-lateral__enlace--activo"
+            #rla3="routerLinkActive" [attr.aria-current]="rla3.isActive ? 'page' : null">
+            <i class="fa-solid fa-chart-line barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.actividad" | translate }}</span>
             <span class="barra-lateral__enlace__indicador" aria-hidden="true"></span>
           </a>
         </li>
         <li>
-          <a class="barra-lateral__enlace" routerLink="/app/billing" routerLinkActive="barra-lateral__enlace--activo">
-            <i class="fa-solid fa-credit-card barra-lateral__enlace__icono"></i>
+          <a class="barra-lateral__enlace" routerLink="/app/billing" routerLinkActive="barra-lateral__enlace--activo"
+            #rla4="routerLinkActive" [attr.aria-current]="rla4.isActive ? 'page' : null">
+            <i class="fa-solid fa-credit-card barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.billing" | translate }}</span>
             <span class="barra-lateral__enlace__indicador" aria-hidden="true"></span>
           </a>
@@ -44,22 +47,24 @@
       </ul>
     </section>
 
-    <section class="barra-lateral__seccion" data-indice="02">
+    <section class="barra-lateral__seccion" data-indice="02" aria-labelledby="barra-lateral-titulo-2">
       <header class="barra-lateral__seccion__cabecera">
         <span class="barra-lateral__seccion__numero" aria-hidden="true">02</span>
-        <span class="barra-lateral__seccion__titulo">{{ "sidebar.secciones.servidor" | translate }}</span>
+        <span class="barra-lateral__seccion__titulo" id="barra-lateral-titulo-2">{{ "sidebar.secciones.servidor" | translate }}</span>
       </header>
       <ul class="barra-lateral__lista">
         <li>
-          <a class="barra-lateral__enlace" routerLink="/app/terminal" routerLinkActive="barra-lateral__enlace--activo">
-            <i class="fa-solid fa-terminal barra-lateral__enlace__icono"></i>
+          <a class="barra-lateral__enlace" routerLink="/app/terminal" routerLinkActive="barra-lateral__enlace--activo"
+            #rla5="routerLinkActive" [attr.aria-current]="rla5.isActive ? 'page' : null">
+            <i class="fa-solid fa-terminal barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.terminal" | translate }}</span>
             <span class="barra-lateral__enlace__indicador" aria-hidden="true"></span>
           </a>
         </li>
         <li>
-          <a class="barra-lateral__enlace" routerLink="/app/asistente-ia" routerLinkActive="barra-lateral__enlace--activo">
-            <i class="fa-solid fa-robot barra-lateral__enlace__icono"></i>
+          <a class="barra-lateral__enlace" routerLink="/app/asistente-ia" routerLinkActive="barra-lateral__enlace--activo"
+            #rla6="routerLinkActive" [attr.aria-current]="rla6.isActive ? 'page' : null">
+            <i class="fa-solid fa-robot barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.asistenteIa" | translate }}</span>
             @if (planService.planActual() !== 'pro' && planService.planActual() !== 'business') {
               <span class="barra-lateral__chip-pro">{{ "sidebar.chipPro" | translate }}</span>
@@ -69,29 +74,33 @@
         </li>
         <li>
           <a class="barra-lateral__enlace" routerLink="/app/nuevo-despliegue"
-            routerLinkActive="barra-lateral__enlace--activo">
-            <i class="fa-solid fa-cubes barra-lateral__enlace__icono"></i>
+            routerLinkActive="barra-lateral__enlace--activo"
+            #rla7="routerLinkActive" [attr.aria-current]="rla7.isActive ? 'page' : null">
+            <i class="fa-solid fa-cubes barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.aplicaciones" | translate }}</span>
             <span class="barra-lateral__enlace__indicador" aria-hidden="true"></span>
           </a>
         </li>
         <li>
-          <a class="barra-lateral__enlace" routerLink="/app/networking" routerLinkActive="barra-lateral__enlace--activo">
-            <i class="fa-solid fa-globe barra-lateral__enlace__icono"></i>
+          <a class="barra-lateral__enlace" routerLink="/app/networking" routerLinkActive="barra-lateral__enlace--activo"
+            #rla8="routerLinkActive" [attr.aria-current]="rla8.isActive ? 'page' : null">
+            <i class="fa-solid fa-globe barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.networking" | translate }}</span>
             <span class="barra-lateral__enlace__indicador" aria-hidden="true"></span>
           </a>
         </li>
         <li>
-          <a class="barra-lateral__enlace" routerLink="/app/firewall" routerLinkActive="barra-lateral__enlace--activo">
-            <i class="fa-solid fa-shield-halved barra-lateral__enlace__icono"></i>
+          <a class="barra-lateral__enlace" routerLink="/app/firewall" routerLinkActive="barra-lateral__enlace--activo"
+            #rla9="routerLinkActive" [attr.aria-current]="rla9.isActive ? 'page' : null">
+            <i class="fa-solid fa-shield-halved barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.firewall" | translate }}</span>
             <span class="barra-lateral__enlace__indicador" aria-hidden="true"></span>
           </a>
         </li>
         <li>
-          <a class="barra-lateral__enlace" routerLink="/app/backups" routerLinkActive="barra-lateral__enlace--activo">
-            <i class="fa-solid fa-hard-drive barra-lateral__enlace__icono"></i>
+          <a class="barra-lateral__enlace" routerLink="/app/backups" routerLinkActive="barra-lateral__enlace--activo"
+            #rla10="routerLinkActive" [attr.aria-current]="rla10.isActive ? 'page' : null">
+            <i class="fa-solid fa-hard-drive barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.backups" | translate }}</span>
             <span class="barra-lateral__enlace__indicador" aria-hidden="true"></span>
           </a>
@@ -101,8 +110,8 @@
   </nav>
 
   <footer class="barra-lateral__inferior">
-    <button class="barra-lateral__colapsar" (click)="alternarColapso()">
-      <i class="barra-lateral__colapsar__icono" [class]="colapsada() ? 'fa-solid fa-angles-right' : 'fa-solid fa-angles-left'"></i>
+    <button class="barra-lateral__colapsar" (click)="alternarColapso()" [attr.aria-label]="'sidebar.ariaColapsar' | translate">
+      <i class="barra-lateral__colapsar__icono" [class]="colapsada() ? 'fa-solid fa-angles-right' : 'fa-solid fa-angles-left'" aria-hidden="true"></i>
       @if (!colapsada()) {
         <span class="barra-lateral__colapsar__texto">{{ "sidebar.colapsar" | translate }}</span>
       }
@@ -111,7 +120,7 @@
       <span class="barra-lateral__usuario__avatar" aria-hidden="true">
         <span class="barra-lateral__usuario__avatar__estado" aria-hidden="true"></span>
       </span>
-      <section class="barra-lateral__usuario__info">
+      <section class="barra-lateral__usuario__info" [attr.aria-label]="'sidebar.ariaInfoUsuario' | translate">
         <span class="barra-lateral__usuario__nombre">{{ usuarioService.nombre() || ("sidebar.fallbackCuenta" | translate) }}</span>
         <span class="barra-lateral__usuario__plan">{{ planService.planActual() }}</span>
       </section>

--- a/autodeploy/src/app/services/theme.service.ts
+++ b/autodeploy/src/app/services/theme.service.ts
@@ -1,20 +1,94 @@
-import { Injectable, signal, effect } from "@angular/core";
+import { DOCUMENT } from "@angular/common";
+import { Injectable, effect, inject, signal } from "@angular/core";
 
 type Tema = "oscuro" | "claro";
 
+const CLAVE_ALMACEN = "tema";
+const CLASE_TEMA_CLARO = "tema-claro";
+
 @Injectable({ providedIn: "root" })
 export class ThemeService {
-  temaActual = signal<Tema>((localStorage.getItem("tema") as Tema) ?? "oscuro");
+  private documento = inject(DOCUMENT);
+
+  // Indica si el usuario eligió tema manualmente (true) o si se está
+  // siguiendo automáticamente la preferencia del sistema (false). Sólo
+  // así puede reaccionar a cambios futuros del SO sin pisar la elección
+  // explícita del usuario.
+  private eleccionManual = signal<boolean>(this.haGuardado());
+
+  temaActual = signal<Tema>(this.temaInicial());
 
   constructor() {
+    // Aplica la clase y persiste sólo si el cambio viene de una elección
+    // manual; al inicializar con la preferencia del sistema no se guarda
+    // para que el usuario pueda volver al modo automático borrando el
+    // localStorage.
     effect(() => {
       const tema = this.temaActual();
-      localStorage.setItem("tema", tema);
-      document.documentElement.classList.toggle("tema-claro", tema === "claro");
+      this.documento.documentElement.classList.toggle(CLASE_TEMA_CLARO, tema === "claro");
+
+      if (this.eleccionManual()) {
+        try {
+          this.almacen()?.setItem(CLAVE_ALMACEN, tema);
+        } catch {
+          // Si localStorage está bloqueado (modo incógnito, política de
+          // privacidad) seguimos funcionando: el tema se mantiene sólo
+          // mientras dura la sesión.
+        }
+      }
     });
+
+    this.escucharSistema();
   }
 
   alternarTema(): void {
+    this.eleccionManual.set(true);
     this.temaActual.update(t => (t === "oscuro" ? "claro" : "oscuro"));
+  }
+
+  private temaInicial(): Tema {
+    const guardado = this.almacen()?.getItem(CLAVE_ALMACEN);
+    if (guardado === "oscuro" || guardado === "claro") {
+      return guardado;
+    }
+    return this.preferenciaDelSistema();
+  }
+
+  private haGuardado(): boolean {
+    const guardado = this.almacen()?.getItem(CLAVE_ALMACEN);
+    return guardado === "oscuro" || guardado === "claro";
+  }
+
+  private preferenciaDelSistema(): Tema {
+    const ventana = this.documento.defaultView;
+    if (!ventana?.matchMedia) {
+      return "oscuro";
+    }
+    return ventana.matchMedia("(prefers-color-scheme: light)").matches ? "claro" : "oscuro";
+  }
+
+  // Suscribe el servicio al cambio de la preferencia del sistema. Si el
+  // usuario nunca ha pulsado el botón de cambio de tema, la app sigue
+  // automáticamente lo que dicte el sistema operativo.
+  private escucharSistema(): void {
+    const ventana = this.documento.defaultView;
+    if (!ventana?.matchMedia) {
+      return;
+    }
+    const consulta = ventana.matchMedia("(prefers-color-scheme: light)");
+    consulta.addEventListener("change", evento => {
+      if (this.eleccionManual()) {
+        return;
+      }
+      this.temaActual.set(evento.matches ? "claro" : "oscuro");
+    });
+  }
+
+  private almacen(): Storage | null {
+    try {
+      return this.documento.defaultView?.localStorage ?? null;
+    } catch {
+      return null;
+    }
   }
 }

--- a/autodeploy/src/styles.scss
+++ b/autodeploy/src/styles.scss
@@ -67,6 +67,10 @@
 @use "styles/06-utilities/visibilidad";
 @use "styles/06-utilities/texto";
 @use "styles/06-utilities/espaciados";
+@use "styles/06-utilities/flex";
+@use "styles/06-utilities/display";
+@use "styles/06-utilities/z-index";
+@use "styles/06-utilities/saltar-contenido";
 
 // Vendor CSS (xterm) — al final para que el reset no lo machaque.
 @import "@xterm/xterm/css/xterm.css";

--- a/autodeploy/src/styles.scss
+++ b/autodeploy/src/styles.scss
@@ -7,8 +7,9 @@
 @use "styles/00-settings/css-variables";
 @use "styles/00-settings/variables";
 
-// 01 · Tools — mixins, helpers y animaciones reutilizables.
+// 01 · Tools — mixins, funciones y animaciones reutilizables.
 @use "styles/01-tools/mixins";
+@use "styles/01-tools/funciones";
 @use "styles/01-tools/animaciones";
 
 // 02 · Generic — reset + design tokens (Custom Properties CSS).

--- a/autodeploy/src/styles/01-tools/_animaciones.scss
+++ b/autodeploy/src/styles/01-tools/_animaciones.scss
@@ -2,6 +2,8 @@
 // Las animaciones específicas de un componente viven con su componente
 // (p.ej. .seccion-bienvenida__terminal__linea está en _seccion-bienvenida.scss).
 
+@use "./mixins" as *;
+
 // Keyframes globales -----------------------------------------------------
 
 @keyframes entrar-abajo {
@@ -33,6 +35,15 @@
 @keyframes latido {
   0%, 100% { transform: scale(1); }
   50%      { transform: scale(1.25); }
+}
+
+@keyframes giro-spinner {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes fade-arriba {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 // Animaciones de carga (page load, sin scroll) ---------------------------
@@ -80,3 +91,64 @@
 .animar-hijos > *:nth-child(4) { animation-delay: 240ms; }
 .animar-hijos > *:nth-child(5) { animation-delay: 320ms; }
 .animar-hijos > *:nth-child(6) { animation-delay: 400ms; }
+
+// Spinner global de carga ------------------------------------------------
+//
+// Se renderiza con un solo div: el borde superior cyan/amarillo gira sobre
+// un círculo grisáceo. Las animaciones se quedan en transform/opacity para
+// que el navegador las componga en GPU.
+
+.spinner {
+  display: inline-block;
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 2px solid var(--borde-normal);
+  border-top-color: var(--amarillo-normal);
+  border-radius: var(--radius-full);
+  animation: giro-spinner 0.8s linear infinite;
+  vertical-align: middle;
+
+  &--grande { width: 2rem; height: 2rem; border-width: 3px; }
+  &--cyan   { border-top-color: var(--cyan-normal); }
+  &--verde  { border-top-color: var(--verde-normal); }
+}
+
+// Micro-interacción "fade desde abajo" para feedback puntual (toasts,
+// confirmaciones, item recién añadido). Más breve que .animar--subir.
+.aparecer {
+  animation: fade-arriba 0.32s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+// Accesibilidad: respetar la preferencia del sistema operativo de
+// reducir movimiento. Si el usuario ha activado "Reduce motion" en
+// macOS/Windows/Android/iOS, las animaciones de entrada y de scroll
+// reveal se desactivan completamente (queda solo el estado final
+// visible) y las transiciones bajan a una duración irrisoria.
+//
+// El uso de !important es legítimo aquí porque la preferencia del
+// usuario es la última palabra: gana sobre cualquier regla específica
+// que un componente pudiera redefinir.
+@include movimiento-reducido {
+  .animar,
+  .animar-hijos > *,
+  .revelar,
+  .aparecer {
+    animation: none !important;
+    transition: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+
+  .spinner {
+    animation-duration: 1.5s !important;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/autodeploy/src/styles/01-tools/_funciones.scss
+++ b/autodeploy/src/styles/01-tools/_funciones.scss
@@ -1,0 +1,65 @@
+// Tools: funciones Sass reutilizables.
+//
+// Las funciones se resuelven en compilación (a diferencia de var(--token),
+// que se resuelve en runtime). Sirven para encapsular lógica matemática y
+// devolver valores derivados: conversiones de unidades, mapeo de tokens y
+// generación de clamp() fluidos.
+
+@use 'sass:math';
+@use 'sass:map';
+@use 'sass:color';
+
+// ── Conversiones de unidades ─────────────────────────────────────────────
+
+// Convierte un número en píxeles a rem, asumiendo base 16. Uso: rem(24) → 1.5rem.
+@function rem($pixeles) {
+  @return math.div($pixeles, 16) * 1rem;
+}
+
+// Convierte píxeles a em respecto a un contexto. Útil para padding sensible
+// a la tipografía del propio elemento. Uso: em(12, 14) → 0.857em.
+@function em($pixeles, $contexto: 16) {
+  @return math.div($pixeles, $contexto) * 1em;
+}
+
+// ── Acceso seguro a mapas ─────────────────────────────────────────────────
+
+// Devuelve el valor de un mapa Sass o aborta con error si la clave no existe.
+// Sirve para escalas tipográficas o de espaciado que viven como mapas.
+@function tomar($mapa, $clave) {
+  @if not map.has-key($mapa, $clave) {
+    @error "La clave '#{$clave}' no existe en el mapa.";
+  }
+  @return map.get($mapa, $clave);
+}
+
+// ── Tipografía y espaciado fluido (clamp generado) ───────────────────────
+
+// Devuelve un clamp() que escala linealmente entre dos valores (mínimo y
+// máximo) en función del viewport, también acotado por dos breakpoints.
+// Uso típico: font-size: fluido(2.5rem, 4.5rem); para títulos hero.
+@function fluido($valor-min, $valor-max, $vp-min: 30rem, $vp-max: 80rem) {
+  $pendiente: math.div($valor-max - $valor-min, $vp-max - $vp-min);
+  $base: $valor-min - ($pendiente * $vp-min);
+  $vw: $pendiente * 100;
+  @return clamp(#{$valor-min}, #{$base} + #{$vw}vw, #{$valor-max});
+}
+
+// ── Atajos a Custom Properties (legibilidad en partials) ─────────────────
+
+@function token-color($nombre)    { @return var(--#{$nombre}); }
+@function token-espacio($nivel)   { @return var(--spacing-size-#{$nivel}); }
+@function token-radio($nivel)     { @return var(--radius-#{$nivel}); }
+@function token-sombra($nivel)    { @return var(--shadow-#{$nivel}); }
+@function token-z($capa)          { @return var(--z-#{$capa}); }
+@function token-duracion($vel)    { @return var(--duration-#{$vel}); }
+
+// ── Accesibilidad: color de texto sobre un fondo ─────────────────────────
+
+// Decide si poner texto claro u oscuro encima de un color HSL en función de
+// su luminosidad. Aproximación rápida al ratio WCAG; conviene afinarla con
+// WebAIM si el fondo está cerca del umbral.
+@function contraste-sobre($color) {
+  $luz: color.channel($color, "lightness", $space: hsl);
+  @return if($luz > 55%, hsl(0, 0%, 10%), hsl(0, 0%, 98%));
+}

--- a/autodeploy/src/styles/01-tools/_mixins.scss
+++ b/autodeploy/src/styles/01-tools/_mixins.scss
@@ -1,60 +1,77 @@
+// Tools: mixins reutilizables.
+//
+// Los mixins van aquí cuando encapsulan código que se repite en varios
+// componentes o cuando aceptan parámetros (@content, argumentos).
+// Para devolver un valor, usar @function en `_funciones.scss`.
+//
+// Categorías:
+//   1. Responsive (breakpoints viewport)
+//   2. Container queries (breakpoints contenedor)
+//   3. Preferencias del usuario (hover, motion, contraste, esquema)
+//   4. Layout (flex, grid, contenedor centrado)
+//   5. Tipografía y texto (truncar)
+//   6. Posicionamiento (centrado-absoluto)
+//   7. Accesibilidad (foco visible, visualmente oculto, disabled)
+//   8. Componentes base (tarjeta, tarjeta interactiva)
+//   9. Efectos (transición, glass, enlace subrayado)
+
 @use "../00-settings/css-variables" as *;
 
-@mixin movil-pequeno {
-  @media (max-width: $breakpoint-sm) {
-    @content;
-  }
-}
+// ── 1. Responsive (viewport) ─────────────────────────────────────────────
 
-@mixin movil {
-  @media (max-width: $breakpoint-md) {
-    @content;
-  }
-}
-
-@mixin tablet {
-  @media (max-width: $breakpoint-lg) {
-    @content;
-  }
-}
-
-@mixin escritorio {
-  @media (min-width: $breakpoint-lg) {
-    @content;
-  }
-}
-
-@mixin escritorio-grande {
-  @media (min-width: $breakpoint-xl) {
-    @content;
-  }
-}
-
+@mixin movil-pequeno     { @media (max-width: $breakpoint-sm) { @content; } }
+@mixin movil             { @media (max-width: $breakpoint-md) { @content; } }
+@mixin tablet            { @media (max-width: $breakpoint-lg) { @content; } }
+@mixin escritorio        { @media (min-width: $breakpoint-lg) { @content; } }
+@mixin escritorio-grande { @media (min-width: $breakpoint-xl) { @content; } }
 @mixin entre($desde, $hasta) {
-  @media (min-width: $desde) and (max-width: $hasta) {
-    @content;
-  }
+  @media (min-width: $desde) and (max-width: $hasta) { @content; }
 }
 
-@mixin solo-tactil {
-  @media (hover: none) and (pointer: coarse) {
-    @content;
-  }
+// ── 2. Container queries (ancho del contenedor padre) ────────────────────
+//
+// Para usarlos, el padre debe tener container-type: inline-size y un
+// container-name (opcional). Sirven cuando un componente reutilizable
+// (tarjeta, lista) tiene que adaptarse según el ancho del contenedor en
+// el que se inserta, no según el viewport.
+
+@mixin contenedor-pequeno { @container (max-width: 28rem) { @content; } }
+@mixin contenedor-mediano { @container (min-width: 28rem) and (max-width: 48rem) { @content; } }
+@mixin contenedor-grande  { @container (min-width: 48rem) { @content; } }
+
+// ── 3. Preferencias del usuario ──────────────────────────────────────────
+
+@mixin solo-tactil        { @media (hover: none) and (pointer: coarse) { @content; } }
+@mixin solo-puntero-fino  { @media (hover: hover) and (pointer: fine)  { @content; } }
+@mixin movimiento-reducido { @media (prefers-reduced-motion: reduce)   { @content; } }
+@mixin contraste-alto     { @media (prefers-contrast: more)            { @content; } }
+@mixin esquema-claro      { @media (prefers-color-scheme: light)       { @content; } }
+@mixin esquema-oscuro     { @media (prefers-color-scheme: dark)        { @content; } }
+
+// ── 4. Layout ────────────────────────────────────────────────────────────
+
+@mixin flex-centro     { display: flex; align-items: center; justify-content: center; }
+@mixin flex-entre      { display: flex; align-items: center; justify-content: space-between; }
+@mixin flex-columna    { display: flex; flex-direction: column; }
+@mixin flex-envoltura  { display: flex; flex-wrap: wrap; }
+
+// Grid responsivo sin media queries: la cuadrícula reflowa por sí sola
+// gracias a auto-fit + minmax. $min es el ancho mínimo de cada columna.
+@mixin grid-auto($min: 16rem, $hueco: var(--spacing-size-2xl)) {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax($min, 1fr));
+  gap: $hueco;
 }
 
-@mixin movimiento-reducido {
-  @media (prefers-reduced-motion: reduce) {
-    @content;
-  }
+// Contenedor centrado con ancho máximo y padding interior.
+@mixin contenedor($ancho: 75rem) {
+  width: 100%;
+  max-width: $ancho;
+  margin-inline: auto;
+  padding-inline: var(--spacing-size-2xl);
 }
 
-@mixin foco-visible {
-  &:focus-visible {
-    outline: 2px solid var(--amarillo-normal);
-    outline-offset: 2px;
-    @content;
-  }
-}
+// ── 5. Tipografía y texto ────────────────────────────────────────────────
 
 @mixin truncar($lineas: 1) {
   display: -webkit-box;
@@ -64,6 +81,8 @@
   text-overflow: ellipsis;
 }
 
+// ── 6. Posicionamiento ───────────────────────────────────────────────────
+
 @mixin centrado-absoluto {
   position: absolute;
   top: 50%;
@@ -71,9 +90,106 @@
   transform: translate(-50%, -50%);
 }
 
+// ── 7. Accesibilidad ─────────────────────────────────────────────────────
+
+@mixin foco-visible {
+  &:focus-visible {
+    outline: 2px solid var(--amarillo-normal);
+    outline-offset: 2px;
+    @content;
+  }
+}
+
+// Oculta visualmente pero deja accesible para lectores de pantalla.
+// Patrón "sr-only". Útil para etiquetas que dan contexto sin ruido visual.
+@mixin visualmente-oculto {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+// Estado deshabilitado coherente para botones, inputs y enlaces.
+@mixin disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+// ── 8. Componentes base ──────────────────────────────────────────────────
+
 @mixin tarjeta-base {
   background-color: var(--fondo-tarjeta);
   border: 1px solid var(--borde-normal);
   border-radius: var(--radius-l);
   padding: var(--spacing-size-2xl);
+}
+
+// Tarjeta interactiva: combina tarjeta-base con transición, hover y foco
+// teclado. Se usa donde la tarjeta es clickable (enlace o botón completo).
+@mixin tarjeta-interactiva {
+  @include tarjeta-base;
+  @include transicion(transform, box-shadow, border-color);
+  cursor: pointer;
+
+  &:hover {
+    transform: translateY(-0.125rem);
+    box-shadow: var(--shadow-hover-amarillo);
+    border-color: var(--amarillo-normal-hover);
+  }
+  &:focus-within {
+    outline: 2px solid var(--amarillo-normal);
+    outline-offset: 2px;
+  }
+}
+
+// ── 9. Efectos ───────────────────────────────────────────────────────────
+
+// Genera una transition con el timing function estándar del proyecto.
+// Acepta varias propiedades y las une con coma.
+@mixin transicion($propiedades...) {
+  $resultado: ();
+  @each $prop in $propiedades {
+    $resultado: append(
+      $resultado,
+      #{$prop} var(--duration-base) cubic-bezier(0.16, 1, 0.3, 1),
+      $separator: comma
+    );
+  }
+  transition: $resultado;
+}
+
+// Fondo translucido con desenfoque (cabeceras, modales).
+@mixin glass($fondo: var(--fondo-cabecera)) {
+  background-color: $fondo;
+  backdrop-filter: blur(0.625rem);
+  -webkit-backdrop-filter: blur(0.625rem);
+}
+
+// Enlace con subrayado animado desde la derecha al hacer hover/foco.
+@mixin enlace-subrayado {
+  position: relative;
+  text-decoration: none;
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: auto 0 -2px 0;
+    height: 2px;
+    background-color: currentColor;
+    transform: scaleX(0);
+    transform-origin: right;
+    @include transicion(transform);
+  }
+
+  &:hover::after,
+  &:focus-visible::after {
+    transform: scaleX(1);
+    transform-origin: left;
+  }
 }

--- a/autodeploy/src/styles/02-generic/_reset.scss
+++ b/autodeploy/src/styles/02-generic/_reset.scss
@@ -13,6 +13,10 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
+  // Transición global suave al alternar tema (clase .tema-claro en <html>).
+  // El @include movimiento-reducido del partial _animaciones.scss anula
+  // esto cuando el usuario tiene prefers-reduced-motion: reduce.
+  transition: background-color var(--duration-base) ease, color var(--duration-base) ease;
 }
 
 ul {

--- a/autodeploy/src/styles/03-elements/_buttons.scss
+++ b/autodeploy/src/styles/03-elements/_buttons.scss
@@ -1,84 +1,82 @@
-.boton--primario {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+@use "../01-tools/mixins" as *;
+
+// Propiedades comunes a todas las variantes de botón. Se extiende con
+// %placeholder para no generar selectores extra en el CSS final.
+%boton-base {
+  @include flex-centro;
   gap: 0.5rem;
   padding: 0.625rem 1.5rem;
-  background-color: var(--amarillo-normal);
-  color: var(--fondo-oscuro);
   font-size: var(--font-size-md);
-  font-weight: var(--font-weight-bold);
-  border: none;
   border-radius: var(--radius-l);
   cursor: pointer;
-  transition: background-color var(--duration-base) ease, transform var(--duration-fast) ease;
+  @include transicion(background-color, border-color, color, transform);
 }
 
-.boton--primario:hover {
-  background-color: var(--amarillo-normal-hover);
-}
+.boton {
+  &--primario {
+    @extend %boton-base;
+    background-color: var(--amarillo-normal);
+    color: var(--fondo-oscuro);
+    font-weight: var(--font-weight-bold);
+    border: none;
 
-.boton--primario:active {
-  transform: scale(0.98);
-}
+    &:hover     { background-color: var(--amarillo-normal-hover); }
+    &:active    { transform: scale(0.98); }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled  { @include disabled; }
+  }
 
-.boton--secundario {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 0.625rem 1.5rem;
-  background: rgba(240, 236, 226, 0.03);
-  color: var(--texto-claro);
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-semibold);
-  border: 1px solid var(--borde-normal);
-  border-radius: var(--radius-l);
-  cursor: pointer;
-  transition: border-color var(--duration-base) ease;
-}
+  &--secundario {
+    @extend %boton-base;
+    background: rgba(240, 236, 226, 0.03);
+    color: var(--texto-claro);
+    font-weight: var(--font-weight-semibold);
+    border: 1px solid var(--borde-normal);
 
-.boton--secundario:hover {
-  border-color: rgba(240, 236, 226, 0.2);
-}
+    &:hover     { border-color: rgba(240, 236, 226, 0.2); }
+    &:active    { transform: scale(0.98); }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled  { @include disabled; }
+  }
 
-.boton--ghost {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 0.625rem 1.5rem;
-  background: transparent;
-  color: var(--texto-medio);
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-semibold);
-  border: 1px solid var(--borde-normal);
-  border-radius: var(--radius-l);
-  cursor: pointer;
-  transition: color var(--duration-base) ease, border-color var(--duration-base) ease;
-}
+  &--ghost {
+    @extend %boton-base;
+    background: transparent;
+    color: var(--texto-medio);
+    font-weight: var(--font-weight-semibold);
+    border: 1px solid var(--borde-normal);
 
-.boton--ghost:hover {
-  color: var(--texto-claro);
-  border-color: rgba(240, 236, 226, 0.2);
-}
+    &:hover {
+      color: var(--texto-claro);
+      border-color: rgba(240, 236, 226, 0.2);
+    }
+    &:active    { transform: scale(0.98); }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled  { @include disabled; }
+  }
 
-.boton--peligro {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 0.625rem 1.5rem;
-  background: rgba(239, 68, 68, 0.08);
-  color: var(--rojo-normal);
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-semibold);
-  border: 1px solid rgba(239, 68, 68, 0.15);
-  border-radius: var(--radius-l);
-  cursor: pointer;
-  transition: background-color var(--duration-base) ease;
-}
+  &--peligro {
+    @extend %boton-base;
+    background: rgba(239, 68, 68, 0.08);
+    color: var(--rojo-normal);
+    font-weight: var(--font-weight-semibold);
+    border: 1px solid rgba(239, 68, 68, 0.15);
 
-.boton--peligro:hover {
-  background: rgba(239, 68, 68, 0.15);
+    &:hover     { background: rgba(239, 68, 68, 0.15); }
+    &:active    { transform: scale(0.98); }
+    &:focus-visible {
+      outline: 2px solid var(--rojo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled  { @include disabled; }
+  }
 }

--- a/autodeploy/src/styles/03-elements/_forms.scss
+++ b/autodeploy/src/styles/03-elements/_forms.scss
@@ -1,83 +1,90 @@
+@use "../01-tools/mixins" as *;
+
 .campo {
-  display: flex;
-  flex-direction: column;
+  @include flex-columna;
   gap: 0.375rem;
-}
 
-.campo__etiqueta {
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-bold);
-  text-transform: uppercase;
-  letter-spacing: 1.5px;
-  color: var(--texto-apagado);
-}
+  &__etiqueta {
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-bold);
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: var(--texto-apagado);
+  }
 
-.campo__input {
-  padding: 0.625rem var(--spacing-size-l);
-  background: rgba(240, 236, 226, 0.03);
-  border: 1px solid var(--borde-normal);
-  border-radius: var(--radius-m);
-  color: var(--texto-claro);
-  font-family: var(--font-primary);
-  font-size: var(--font-size-md);
-  transition: border-color var(--duration-base) ease;
-}
+  &__input {
+    padding: 0.625rem var(--spacing-size-l);
+    background: rgba(240, 236, 226, 0.03);
+    border: 1px solid var(--borde-normal);
+    border-radius: var(--radius-m);
+    color: var(--texto-claro);
+    font-family: var(--font-primary);
+    font-size: var(--font-size-md);
+    @include transicion(border-color);
 
-.campo__input::placeholder {
-  color: var(--texto-apagado);
-}
+    &::placeholder { color: var(--texto-apagado); }
 
-.campo__input:focus {
-  outline: none;
-  border-color: var(--amarillo-normal);
-}
+    &:focus {
+      outline: none;
+      border-color: var(--amarillo-normal);
+    }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled { @include disabled; }
+    &:invalid:not(:focus) { border-color: var(--rojo-normal); }
+  }
 
-.campo__input:focus-visible {
-  outline: 2px solid var(--amarillo-normal);
-  outline-offset: 2px;
-}
+  &__textarea {
+    padding: 0.625rem var(--spacing-size-l);
+    background: rgba(240, 236, 226, 0.03);
+    border: 1px solid var(--borde-normal);
+    border-radius: var(--radius-m);
+    color: var(--texto-claro);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-sm);
+    resize: vertical;
+    @include transicion(border-color);
 
-.campo__textarea {
-  padding: 0.625rem var(--spacing-size-l);
-  background: rgba(240, 236, 226, 0.03);
-  border: 1px solid var(--borde-normal);
-  border-radius: var(--radius-m);
-  color: var(--texto-claro);
-  font-family: var(--font-mono);
-  font-size: var(--font-size-sm);
-  resize: vertical;
-  transition: border-color var(--duration-base) ease;
-}
+    &::placeholder { color: var(--texto-apagado); }
 
-.campo__textarea::placeholder {
-  color: var(--texto-apagado);
-}
+    &:focus {
+      outline: none;
+      border-color: var(--amarillo-normal);
+    }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled { @include disabled; }
+    &:invalid:not(:focus) { border-color: var(--rojo-normal); }
+  }
 
-.campo__textarea:focus {
-  outline: none;
-  border-color: var(--amarillo-normal);
-}
+  &__pista {
+    font-size: var(--font-size-xs);
+    color: var(--texto-apagado);
+  }
 
-.campo__textarea:focus-visible {
-  outline: 2px solid var(--amarillo-normal);
-  outline-offset: 2px;
-}
+  &__select {
+    padding: 0.625rem var(--spacing-size-l);
+    background: rgba(240, 236, 226, 0.03);
+    border: 1px solid var(--borde-normal);
+    border-radius: var(--radius-m);
+    color: var(--texto-claro);
+    font-family: var(--font-primary);
+    font-size: var(--font-size-md);
+    appearance: none;
+    cursor: pointer;
+    @include transicion(border-color);
 
-.campo__pista {
-  font-size: var(--font-size-xs);
-  color: var(--texto-apagado);
-}
-
-.campo__select {
-  padding: 0.625rem var(--spacing-size-l);
-  background: rgba(240, 236, 226, 0.03);
-  border: 1px solid var(--borde-normal);
-  border-radius: var(--radius-m);
-  color: var(--texto-claro);
-  font-family: var(--font-primary);
-  font-size: var(--font-size-md);
-  appearance: none;
-  cursor: pointer;
+    &:focus { outline: none; border-color: var(--amarillo-normal); }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled { @include disabled; }
+  }
 }
 
 .toggle {
@@ -85,23 +92,30 @@
   border: 1px solid var(--borde-normal);
   border-radius: var(--radius-m);
   overflow: hidden;
-}
 
-.toggle__opcion {
-  padding: 0.5rem 1.25rem;
-  background: transparent;
-  color: var(--texto-medio);
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-semibold);
-  border: none;
-  cursor: pointer;
-  transition: background-color var(--duration-base) ease, color var(--duration-base) ease;
-}
+  &__opcion {
+    padding: 0.5rem 1.25rem;
+    background: transparent;
+    color: var(--texto-medio);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+    border: none;
+    cursor: pointer;
+    @include transicion(background-color, color);
 
-.toggle__opcion--activa {
-  background-color: rgba(245, 214, 35, 0.1);
-  color: var(--amarillo-normal);
-  border-left: 2px solid var(--amarillo-normal);
+    &--activa {
+      background-color: rgba(245, 214, 35, 0.1);
+      color: var(--amarillo-normal);
+      border-left: 2px solid var(--amarillo-normal);
+    }
+
+    &:hover:not(&--activa) { color: var(--texto-claro); }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: -2px;
+    }
+    &:disabled { @include disabled; }
+  }
 }
 
 .interruptor {
@@ -113,29 +127,26 @@
   padding: 0;
   border-radius: var(--radius-full);
   cursor: pointer;
-  transition: background-color var(--duration-base) ease;
-}
+  @include transicion(background-color);
 
-.interruptor:focus-visible {
-  outline: 2px solid var(--amarillo-normal);
-  outline-offset: 2px;
-}
+  &--activo { background-color: var(--amarillo-normal); }
 
-.interruptor--activo {
-  background-color: var(--amarillo-normal);
-}
+  &:focus-visible {
+    outline: 2px solid var(--amarillo-normal);
+    outline-offset: 2px;
+  }
+  &:disabled { @include disabled; }
 
-.interruptor__circulo {
-  position: absolute;
-  top: 0.1875rem;
-  left: 0.1875rem;
-  width: 1.125rem;
-  height: 1.125rem;
-  background-color: white;
-  border-radius: 50%;
-  transition: transform var(--duration-base) ease;
-}
+  &__circulo {
+    position: absolute;
+    top: 0.1875rem;
+    left: 0.1875rem;
+    width: 1.125rem;
+    height: 1.125rem;
+    background-color: white;
+    border-radius: 50%;
+    @include transicion(transform);
 
-.interruptor__circulo--activo {
-  transform: translateX(1.25rem);
+    &--activo { transform: translateX(1.25rem); }
+  }
 }

--- a/autodeploy/src/styles/04-layout/_layout.scss
+++ b/autodeploy/src/styles/04-layout/_layout.scss
@@ -21,8 +21,16 @@
   display: none;
 }
 
+// El backdrop es un <button type="button"> (semánticamente: control que
+// cierra el menú al pulsar fuera). Hay que resetear los estilos por
+// defecto del botón para que actúe como una capa transparente.
 .disposicion-app__backdrop {
   display: none;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  cursor: pointer;
+  appearance: none;
 }
 
 @media (max-width: 768px) {

--- a/autodeploy/src/styles/05-components/_barra-lateral.scss
+++ b/autodeploy/src/styles/05-components/_barra-lateral.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .barra-lateral {
   position: sticky;
   top: 0;
@@ -25,7 +27,7 @@
     pointer-events: none;
   }
 
-  @media (max-width: 768px) {
+  @include movil {
     position: fixed;
     top: 0;
     left: 0;
@@ -459,7 +461,7 @@
 
   // ───── Modificador: abierta (mobile) ─────
   &--abierta {
-    @media (max-width: 768px) {
+    @include movil {
       transform: translateX(0);
     }
   }

--- a/autodeploy/src/styles/05-components/_barra-lateral.scss
+++ b/autodeploy/src/styles/05-components/_barra-lateral.scss
@@ -183,7 +183,13 @@
       outline-offset: -2px;
     }
 
-    &--activo {
+    // El estado "página activa" se aplica tanto por la clase BEM
+    // --activo (puesta por routerLinkActive de Angular) como por el
+    // atributo aria-current="page", que es el que leen los lectores
+    // de pantalla. Ambos selectores se mantienen para que la regla
+    // funcione aunque sólo se use uno de los dos enfoques.
+    &--activo,
+    &[aria-current="page"] {
       color: var(--amarillo-normal);
       background: linear-gradient(90deg, hsla(47, 86%, 56%, 0.08), transparent 70%);
 

--- a/autodeploy/src/styles/05-components/_gestion-servidor.scss
+++ b/autodeploy/src/styles/05-components/_gestion-servidor.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .gestion-servidor {
   display: flex;
   flex-direction: column;
@@ -15,7 +17,7 @@
     letter-spacing: 0.04em;
     color: var(--texto-medio);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-wrap: wrap;
     }
   }
@@ -41,7 +43,7 @@
     align-items: flex-start;
     justify-content: space-between;
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: var(--spacing-size-l);
@@ -105,7 +107,7 @@
     align-items: center;
     justify-content: space-between;
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: var(--spacing-size-l);
@@ -135,7 +137,7 @@
       border-color: var(--amarillo-normal);
     }
 
-    @media (max-width: 768px) {
+    @include movil {
       min-width: unset;
       width: 100%;
     }
@@ -201,7 +203,7 @@
     display: flex;
     gap: var(--spacing-size-l);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
     }
 
@@ -262,7 +264,7 @@
       outline-offset: 2px;
     }
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: var(--spacing-size-l);
@@ -368,7 +370,7 @@
     display: flex;
     gap: var(--spacing-size-l);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
     }
   }
@@ -491,7 +493,7 @@
     padding: var(--spacing-size-2xl);
     border-top: 1px solid var(--borde-normal);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-wrap: wrap;
       gap: var(--spacing-size-l);
     }

--- a/autodeploy/src/styles/05-components/_logs-terminal.scss
+++ b/autodeploy/src/styles/05-components/_logs-terminal.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .logs-terminal {
   display: flex;
   flex-direction: column;
@@ -7,7 +9,7 @@
   &__cabecera {
     align-items: flex-end;
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: var(--spacing-size-l);
@@ -24,7 +26,7 @@
       align-items: center;
       gap: var(--spacing-size-l);
 
-      @media (max-width: 768px) {
+      @include movil {
         flex-wrap: wrap;
         gap: var(--spacing-size-m);
       }
@@ -64,7 +66,7 @@
       border-color: var(--amarillo-normal);
     }
 
-    @media (max-width: 768px) {
+    @include movil {
       min-width: unset;
       width: 100%;
     }
@@ -101,7 +103,7 @@
     align-items: center;
     justify-content: space-between;
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: var(--spacing-size-m);
@@ -113,7 +115,7 @@
     align-items: center;
     gap: 0.25rem;
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-wrap: wrap;
     }
   }

--- a/autodeploy/src/styles/05-components/_nuevo-despliegue.scss
+++ b/autodeploy/src/styles/05-components/_nuevo-despliegue.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .nuevo-despliegue {
   display: flex;
   flex-direction: column;
@@ -8,7 +10,7 @@
     align-items: center;
     justify-content: space-between;
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: var(--spacing-size-l);
@@ -70,7 +72,7 @@
     display: flex;
     gap: var(--spacing-size-l);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
     }
 
@@ -136,7 +138,7 @@
     display: flex;
     gap: var(--spacing-size-3xl);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
     }
   }
@@ -145,7 +147,7 @@
     display: flex;
     gap: var(--spacing-size-l);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
     }
   }
@@ -255,7 +257,7 @@
     padding-top: var(--spacing-size-2xl);
     border-top: 1px solid var(--borde-normal);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column-reverse;
     }
   }

--- a/autodeploy/src/styles/05-components/_pagina-comunidad.scss
+++ b/autodeploy/src/styles/05-components/_pagina-comunidad.scss
@@ -1,4 +1,5 @@
 @use "../00-settings/css-variables" as *;
+@use "../01-tools/mixins" as *;
 
 .pagina-comunidad {
   &__canales {
@@ -111,7 +112,7 @@
     border: 1px solid var(--borde-normal);
     border-radius: var(--radius-2xl);
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       padding: var(--spacing-size-3xl) var(--spacing-size-l);
     }
 

--- a/autodeploy/src/styles/05-components/_pagina-contacto.scss
+++ b/autodeploy/src/styles/05-components/_pagina-contacto.scss
@@ -1,4 +1,5 @@
 @use "../00-settings/css-variables" as *;
+@use "../01-tools/mixins" as *;
 
 .pagina-contacto {
   display: grid;
@@ -18,7 +19,7 @@
     border: 1px solid var(--borde-normal);
     border-radius: var(--radius-xl);
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       padding: var(--spacing-size-2xl);
     }
   }
@@ -134,7 +135,7 @@
     border-radius: var(--radius-xl);
     height: fit-content;
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       padding: var(--spacing-size-2xl);
     }
   }

--- a/autodeploy/src/styles/05-components/_pagina-documentacion.scss
+++ b/autodeploy/src/styles/05-components/_pagina-documentacion.scss
@@ -1,4 +1,4 @@
-@use "../00-settings/css-variables" as *;
+@use "../01-tools/mixins" as *;
 
 .pagina-documentacion {
   &__categoria {
@@ -13,7 +13,7 @@
       gap: 0.25rem var(--spacing-size-m);
       align-items: center;
 
-      @media (max-width: $breakpoint-md) {
+      @include movil {
         grid-template-columns: 1fr;
       }
     }
@@ -31,7 +31,7 @@
       display: flex;
       align-items: center;
 
-      @media (max-width: $breakpoint-md) {
+      @include movil {
         grid-row: auto;
         width: fit-content;
       }
@@ -82,7 +82,7 @@
       padding-left: var(--spacing-size-m);
     }
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       grid-template-columns: auto 1fr;
       gap: var(--spacing-size-m);
     }
@@ -125,7 +125,7 @@
       border-radius: var(--radius-full);
       white-space: nowrap;
 
-      @media (max-width: $breakpoint-md) {
+      @include movil {
         grid-column: 2 / -1;
         justify-self: start;
         margin-top: var(--spacing-size-xs);

--- a/autodeploy/src/styles/05-components/_pagina-estado.scss
+++ b/autodeploy/src/styles/05-components/_pagina-estado.scss
@@ -1,4 +1,4 @@
-@use "../00-settings/css-variables" as *;
+@use "../01-tools/mixins" as *;
 
 .pagina-estado {
   &__banner {
@@ -85,7 +85,7 @@
       background-color: rgba(240, 236, 226, 0.03);
     }
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       padding: var(--spacing-size-m) var(--spacing-size-l);
       gap: var(--spacing-size-m);
     }
@@ -124,7 +124,7 @@
       font-weight: var(--font-weight-semibold);
       color: var(--texto-claro);
 
-      @media (max-width: $breakpoint-md) {
+      @include movil {
         font-size: var(--font-size-md);
       }
     }

--- a/autodeploy/src/styles/05-components/_pagina-legal.scss
+++ b/autodeploy/src/styles/05-components/_pagina-legal.scss
@@ -1,9 +1,11 @@
+@use "../01-tools/mixins" as *;
+
 .pagina-legal {
   background-color: var(--fondo-oscuro);
   min-height: calc(100vh - 3.5rem);
   padding: var(--spacing-size-6xl) var(--spacing-size-3xl);
 
-  @media (max-width: 768px) {
+  @include movil {
     padding: var(--spacing-size-4xl) var(--spacing-size-2xl);
   }
 
@@ -20,7 +22,7 @@
     margin-bottom: var(--spacing-size-s);
     line-height: var(--line-height-tight);
 
-    @media (max-width: 768px) {
+    @include movil {
       font-size: var(--font-size-3xl);
     }
   }
@@ -83,7 +85,7 @@
     border-radius: var(--radius-m);
     overflow: hidden;
 
-    @media (max-width: 768px) {
+    @include movil {
       display: block;
       overflow-x: auto;
     }

--- a/autodeploy/src/styles/05-components/_pagina-login.scss
+++ b/autodeploy/src/styles/05-components/_pagina-login.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/funciones" as *;
+
 .pagina-login {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
@@ -72,7 +74,9 @@
 
     &__titular {
       font-family: var(--font-secondary);
-      font-size: clamp(2.5rem, 5vw, 3.75rem);
+      // Generado con la función fluido() (equivalente al clamp manual,
+      // pero declarativo y reusable).
+      font-size: fluido(2.5rem, 3.75rem);
       font-weight: var(--font-weight-bold);
       letter-spacing: -0.045em;
       line-height: 0.95;

--- a/autodeploy/src/styles/05-components/_pagina-recursos.scss
+++ b/autodeploy/src/styles/05-components/_pagina-recursos.scss
@@ -1,4 +1,4 @@
-@use "../00-settings/css-variables" as *;
+@use "../01-tools/mixins" as *;
 
 .pagina-recursos {
   background-color: var(--fondo-oscuro);
@@ -10,7 +10,7 @@
   max-width: 72rem;
   margin: 0 auto;
 
-  @media (max-width: $breakpoint-md) {
+  @include movil {
     padding: var(--spacing-size-4xl) var(--spacing-size-l);
   }
 
@@ -22,7 +22,7 @@
     padding-bottom: var(--spacing-size-3xl);
     border-bottom: 1px solid var(--borde-normal);
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       grid-template-columns: 1fr;
       align-items: flex-start;
     }
@@ -40,7 +40,7 @@
       gap: 0.25rem;
       text-align: right;
 
-      @media (max-width: $breakpoint-md) {
+      @include movil {
         align-items: flex-start;
         text-align: left;
       }
@@ -103,7 +103,7 @@
     grid-template-columns: repeat(2, 1fr);
     gap: var(--spacing-size-2xl);
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       grid-template-columns: 1fr;
     }
   }
@@ -130,7 +130,7 @@
       outline-offset: 2px;
     }
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       padding: var(--spacing-size-2xl);
     }
 
@@ -201,7 +201,7 @@
     color: var(--texto-claro);
     flex-wrap: wrap;
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       gap: var(--spacing-size-s);
     }
 
@@ -226,7 +226,7 @@
       font-size: var(--font-size-md);
       margin-left: auto;
 
-      @media (max-width: $breakpoint-md) {
+      @include movil {
         margin-left: 0;
         width: 100%;
       }

--- a/autodeploy/src/styles/05-components/_seccion-bienvenida.scss
+++ b/autodeploy/src/styles/05-components/_seccion-bienvenida.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/funciones" as *;
+
 .seccion-bienvenida {
   display: grid;
   grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.95fr);
@@ -51,19 +53,19 @@
   // ───── Título y descripción (editorial tipo magazine) ─────
   &__titulo {
     font-family: var(--font-secondary);
-    font-size: clamp(2.75rem, 5.5vw, 4.5rem);
+    // Tipografía fluida generada por la función fluido(): escala entre
+    // 2.5rem y 4.5rem según el viewport (30rem→80rem). El clamp() final
+    // sustituye al pareja `clamp()` manual + @media de 960px que había
+    // antes.
+    font-size: fluido(2.5rem, 4.5rem);
     font-weight: var(--font-weight-bold);
     line-height: 0.95;
     letter-spacing: -0.045em;
     color: var(--texto-claro);
-
-    @media (max-width: 960px) {
-      font-size: 2.5rem;
-    }
   }
 
   &__descripcion {
-    font-size: 1.05rem;
+    font-size: fluido(0.95rem, 1.125rem);
     line-height: 1.65;
     color: var(--texto-medio);
     max-width: 32rem;

--- a/autodeploy/src/styles/05-components/_seccion-funcionalidades.scss
+++ b/autodeploy/src/styles/05-components/_seccion-funcionalidades.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .seccion-funcionalidades {
   display: flex;
   flex-direction: column;
@@ -41,7 +43,7 @@
       flex: 1;
     }
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
     }
   }
@@ -71,7 +73,7 @@
         margin-bottom: 0;
       }
 
-      @media (max-width: 768px) {
+      @include movil {
         flex-direction: column;
         gap: 1rem;
       }

--- a/autodeploy/src/styles/05-components/_seccion-llamada-accion.scss
+++ b/autodeploy/src/styles/05-components/_seccion-llamada-accion.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .seccion-llamada-accion {
   padding: 2rem 0 4rem;
 
@@ -11,7 +13,7 @@
     border: 1px solid var(--borde-normal);
     border-radius: var(--radius-l);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: 2rem;

--- a/autodeploy/src/styles/05-components/_seccion-precios.scss
+++ b/autodeploy/src/styles/05-components/_seccion-precios.scss
@@ -73,6 +73,10 @@
     transform: translateY(-2px);
   }
 
+  &:active {
+    transform: translateY(-1px);
+  }
+
   &:focus-within {
     outline: 2px solid var(--amarillo-normal);
     outline-offset: 2px;

--- a/autodeploy/src/styles/05-components/_tabla-sitios.scss
+++ b/autodeploy/src/styles/05-components/_tabla-sitios.scss
@@ -65,6 +65,10 @@
       background-color: rgba(240, 236, 226, 0.03);
     }
 
+    &:active {
+      background-color: rgba(240, 236, 226, 0.06);
+    }
+
     &:focus-within {
       background-color: rgba(240, 236, 226, 0.05);
       outline: 2px solid var(--amarillo-normal);

--- a/autodeploy/src/styles/05-components/_tarjeta-estadistica.scss
+++ b/autodeploy/src/styles/05-components/_tarjeta-estadistica.scss
@@ -76,11 +76,17 @@
     &--cyan        { color: var(--verde-normal); }
   }
 
-  // Estado interactivo: hover ligero, foco visible para accesibilidad.
+  // Estado interactivo: hover ligero, foco visible para accesibilidad,
+  // active para feedback táctil al pulsar.
   &:hover {
     transform: translateY(-0.125rem);
     box-shadow: var(--shadow-hover-amarillo);
     border-color: var(--amarillo-normal-hover);
+  }
+
+  &:active {
+    transform: translateY(0);
+    box-shadow: var(--shadow-sm);
   }
 
   &:focus-within {

--- a/autodeploy/src/styles/05-components/_tarjeta-estadistica.scss
+++ b/autodeploy/src/styles/05-components/_tarjeta-estadistica.scss
@@ -1,4 +1,14 @@
+// Container queries: la tarjeta de estadística aparece en el grid del
+// dashboard (~280px), en el panel principal (~360px) y a veces en el
+// modal de detalle (>500px). Adaptar la jerarquía interna al ancho del
+// contenedor evita tener que duplicar la regla por viewport.
+
+@use "../01-tools/mixins" as *;
+
 .tarjeta-stat {
+  container-type: inline-size;
+  container-name: tarjeta-stat;
+
   display: flex;
   flex-direction: column;
   gap: var(--spacing-size-m);
@@ -92,5 +102,19 @@
   &:focus-within {
     outline: 2px solid var(--amarillo-normal);
     outline-offset: 2px;
+  }
+
+  // En contenedores estrechos la barra de progreso ocupa toda la
+  // anchura y el subtexto pasa debajo del valor para no apretar.
+  @include contenedor-pequeno {
+    &__cabecera { flex-wrap: wrap; gap: var(--spacing-size-xs); }
+    &__valor    { font-size: 1.5rem; }
+  }
+
+  // En contenedores anchos el valor crece y la barra de progreso se
+  // alinea a la derecha del valor para una lectura más rápida.
+  @include contenedor-grande {
+    &__valor    { font-size: 2.25rem; }
+    &__cabecera { gap: var(--spacing-size-m); }
   }
 }

--- a/autodeploy/src/styles/05-components/_tarjeta-servidor.scss
+++ b/autodeploy/src/styles/05-components/_tarjeta-servidor.scss
@@ -146,6 +146,11 @@
     border-color: var(--amarillo-normal-hover);
   }
 
+  &:active {
+    transform: translateY(0);
+    box-shadow: var(--shadow-sm);
+  }
+
   &:focus-within {
     outline: 2px solid var(--amarillo-normal);
     outline-offset: 2px;

--- a/autodeploy/src/styles/05-components/_tarjeta-servidor.scss
+++ b/autodeploy/src/styles/05-components/_tarjeta-servidor.scss
@@ -4,8 +4,19 @@
 //   .tarjeta-servidor--variante     · modificadores
 // Estados :hover y :focus-within definidos al final del bloque, usando las
 // variables --*-hover / --shadow-* del design-tokens.
+//
+// Container queries:
+// Se declara container-type para que el ancho del propio bloque condicione
+// la disposición de los elementos internos. Así la misma tarjeta se ve
+// distinta en una sidebar estrecha (~280px) que en un grid amplio (~360px)
+// o en un panel detalle (>600px) sin depender de breakpoints del viewport.
+
+@use "../01-tools/mixins" as *;
 
 .tarjeta-servidor {
+  container-type: inline-size;
+  container-name: tarjeta-servidor;
+
   display: flex;
   flex-direction: column;
   gap: var(--spacing-size-m);
@@ -154,5 +165,23 @@
   &:focus-within {
     outline: 2px solid var(--amarillo-normal);
     outline-offset: 2px;
+  }
+
+  // En contenedores muy estrechos (sidebar plegado, columna lateral
+  // <28rem), la IP es información secundaria y se oculta para dejar
+  // espacio al nombre y al indicador.
+  @include contenedor-pequeno {
+    &__ip { display: none; }
+    &__metricas { gap: var(--spacing-size-xs); }
+  }
+
+  // En contenedores anchos (panel detalle, modal expandido) las dos
+  // métricas pasan a fila para aprovechar el espacio.
+  @include contenedor-grande {
+    &__metricas {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: var(--spacing-size-l);
+    }
   }
 }

--- a/autodeploy/src/styles/05-components/_workflow.scss
+++ b/autodeploy/src/styles/05-components/_workflow.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .workflow {
   display: flex;
   flex-direction: column;
@@ -69,7 +71,7 @@
       max-width: 36rem;
     }
 
-    @media (max-width: 768px) {
+    @include movil {
       gap: 1.25rem;
     }
   }

--- a/autodeploy/src/styles/06-utilities/_display.scss
+++ b/autodeploy/src/styles/06-utilities/_display.scss
@@ -1,0 +1,17 @@
+// Utilities · Display
+//
+// Helpers para forzar el modo de visualización. Útiles cuando hay que
+// alternar layouts sin tocar el componente: por ejemplo, ocultar una
+// columna en móvil sin replicar la regla en cada partial.
+
+@use "../01-tools/mixins" as *;
+
+.u-bloque          { display: block; }
+.u-en-linea        { display: inline; }
+.u-en-linea-bloque { display: inline-block; }
+.u-grid            { display: grid; }
+
+// Visibilidad condicional según viewport.
+.u-oculto-movil      { @include movil      { display: none; } }
+.u-oculto-tablet     { @include tablet     { display: none; } }
+.u-oculto-escritorio { @include escritorio { display: none; } }

--- a/autodeploy/src/styles/06-utilities/_flex.scss
+++ b/autodeploy/src/styles/06-utilities/_flex.scss
@@ -1,0 +1,19 @@
+// Utilities · Flex
+//
+// Helpers de Flexbox para casos puntuales. La cascada ITCSS pone esta
+// capa al final, por lo que estas clases ganan al componente sin
+// necesidad de !important.
+
+.u-flex            { display: flex; }
+.u-flex-centro     { display: flex; align-items: center; justify-content: center; }
+.u-flex-entre      { display: flex; align-items: center; justify-content: space-between; }
+.u-flex-columna    { display: flex; flex-direction: column; }
+.u-flex-envoltura  { display: flex; flex-wrap: wrap; }
+
+// Hueco entre hijos de un contenedor flex/grid. Acepta los mismos
+// niveles que el sistema de spacing del proyecto.
+.u-gap-xs { gap: var(--spacing-size-xs); }
+.u-gap-s  { gap: var(--spacing-size-s); }
+.u-gap-m  { gap: var(--spacing-size-m); }
+.u-gap-l  { gap: var(--spacing-size-l); }
+.u-gap-xl { gap: var(--spacing-size-xl); }

--- a/autodeploy/src/styles/06-utilities/_saltar-contenido.scss
+++ b/autodeploy/src/styles/06-utilities/_saltar-contenido.scss
@@ -1,0 +1,36 @@
+// Utilities · Skip link "Saltar al contenido"
+//
+// Utilidad accesible para el primer elemento que reciben los usuarios
+// de teclado y lectores de pantalla. Permanece oculto visualmente
+// hasta que recibe foco; entonces aparece arriba a la izquierda con
+// z-index alto para sobreponerse al header.
+
+@use "../01-tools/mixins" as *;
+
+.u-saltar-contenido {
+  @include visualmente-oculto;
+
+  // Cuando recibe foco (tab desde el inicio del documento), pasa a
+  // ser un enlace visible que el usuario puede activar con Enter.
+  &:focus-visible {
+    position: fixed;
+    top: var(--spacing-size-l);
+    left: var(--spacing-size-l);
+    width: auto;
+    height: auto;
+    padding: var(--spacing-size-s) var(--spacing-size-l);
+    margin: 0;
+    overflow: visible;
+    clip: auto;
+    white-space: normal;
+    background-color: var(--amarillo-normal);
+    color: var(--fondo-oscuro);
+    font-weight: var(--font-weight-bold);
+    text-decoration: none;
+    border-radius: var(--radius-m);
+    box-shadow: var(--shadow-md);
+    z-index: 9999;
+    outline: 2px solid var(--fondo-oscuro);
+    outline-offset: 2px;
+  }
+}

--- a/autodeploy/src/styles/06-utilities/_z-index.scss
+++ b/autodeploy/src/styles/06-utilities/_z-index.scss
@@ -1,0 +1,10 @@
+// Utilities · Z-Index
+//
+// Wrappers sobre los tokens de capa. Evitan que los componentes
+// escriban valores numéricos sueltos.
+
+.u-z-sidebar   { z-index: var(--z-sidebar); }
+.u-z-header    { z-index: var(--z-header); }
+.u-z-dropdown  { z-index: var(--z-dropdown); }
+.u-z-modal     { z-index: var(--z-modal); }
+.u-z-toast     { z-index: var(--z-toast); }

--- a/autodeploy/src/styles/README.md
+++ b/autodeploy/src/styles/README.md
@@ -6,7 +6,7 @@ Los estilos de AutoDeploy siguen [ITCSS](https://itcss.io/) (Inverted Triangle C
 
 ```
 00-settings     · solo variables Sass ($var). No genera CSS.
-01-tools        · mixins, helpers, keyframes y animaciones reutilizables.
+01-tools        · mixins, funciones y keyframes/animaciones reutilizables.
 02-generic      · reset + design tokens (CSS Custom Properties).
 03-elements     · estilos base sobre tags HTML (button, input, a, …).
 04-layout       · estructura de página (header, main, footer, grid).
@@ -39,12 +39,117 @@ El error contrario también es común: justificar el orden de carga de Settings 
 |------------------------------|------|---------|
 | Una Sass var (`$breakpoint-md: 768px`) | `00-settings` | `_css-variables.scss`, `_variables.scss` |
 | Una Custom Property visible al navegador (`--amarillo-normal`) | `02-generic` | `_design-tokens.scss` |
-| Un mixin o un keyframe global | `01-tools` | `@mixin movil`, `@keyframes entrar-abajo`, `.animar` |
+| Un mixin con `@content` o parámetros | `01-tools` | `_mixins.scss` |
+| Una función (`@function`) que devuelve un valor | `01-tools` | `_funciones.scss` |
+| Un keyframe o una clase de animación global | `01-tools` | `_animaciones.scss` (`.animar`, `.revelar`, `.spinner`, `.aparecer`) |
 | Un reset o un `box-sizing: border-box;` global | `02-generic` | `_reset.scss` |
 | Estilos base sobre `button`, `input`, `a`… sin clase | `03-elements` | `_buttons.scss`, `_forms.scss` |
 | Estructura de página: header, sidebar, grid principal | `04-layout` | `_layout.scss` |
 | Un componente o sección con su bloque BEM (`.tarjeta-X`, `.pagina-X`) | `05-components` | `_pagina-login.scss`, `_tarjeta-servidor.scss` |
-| Un helper transversal tipo `.u-oculto`, `.u-texto-centrado` | `06-utilities` | `_visibilidad.scss`, `_texto.scss`, `_espaciados.scss` |
+| Un helper transversal tipo `.u-oculto`, `.u-flex-centro` | `06-utilities` | `_visibilidad.scss`, `_flex.scss`, `_display.scss`, `_z-index.scss`, `_saltar-contenido.scss` |
+
+## Mixins disponibles (`01-tools/_mixins.scss`)
+
+| Mixin | Para qué sirve | Ejemplo de uso |
+|---|---|---|
+| `@include movil-pequeno` | Media query `max-width: $breakpoint-sm` (576px) | `@include movil-pequeno { ... }` |
+| `@include movil` | Media query `max-width: $breakpoint-md` (768px) | `@include movil { padding: 1rem; }` |
+| `@include tablet` | Media query `max-width: $breakpoint-lg` (992px) | `@include tablet { ... }` |
+| `@include escritorio` | Media query `min-width: $breakpoint-lg` | `@include escritorio { ... }` |
+| `@include escritorio-grande` | Media query `min-width: $breakpoint-xl` (1200px) | |
+| `@include entre($a, $b)` | Rango personalizado | `@include entre(720px, 960px) { ... }` |
+| `@include solo-tactil` | `(hover: none) and (pointer: coarse)` | Pulsa el dispositivo (móvil/tablet sin ratón) |
+| `@include solo-puntero-fino` | `(hover: hover) and (pointer: fine)` | Sólo cuando hay ratón con precisión |
+| `@include movimiento-reducido` | `prefers-reduced-motion: reduce` | Bloquea animaciones para usuarios sensibles |
+| `@include contraste-alto` | `prefers-contrast: more` | Reforzar bordes/texto |
+| `@include esquema-claro` / `oscuro` | `prefers-color-scheme: ...` | Fallback si no hay theme switcher |
+| `@include contenedor-pequeno/mediano/grande` | Container queries | Requiere `container-type: inline-size` en el ancestro |
+| `@include flex-centro` | `display:flex; align-items:center; justify-content:center;` | El mixin más usado del proyecto |
+| `@include flex-entre` | Flex con `space-between` | |
+| `@include flex-columna` | Flex en columna | |
+| `@include flex-envoltura` | Flex con `flex-wrap: wrap` | |
+| `@include grid-auto($min, $hueco)` | Grid responsivo `auto-fit + minmax` | `@include grid-auto(16rem)` |
+| `@include contenedor($ancho)` | Ancho máximo + márgenes centrados | `@include contenedor(64rem)` |
+| `@include transicion($props...)` | Transition con timing function unificado | `@include transicion(opacity, transform)` |
+| `@include foco-visible` | `:focus-visible` con outline amarillo estándar | Dentro de un selector |
+| `@include truncar($lineas)` | Ellipsis multi-línea | `@include truncar(2)` |
+| `@include centrado-absoluto` | `position:absolute; top:50%; left:50%; translate(-50%,-50%)` | |
+| `@include visualmente-oculto` | Patrón sr-only (oculto visual, accesible) | Para labels invisibles |
+| `@include disabled` | `opacity:0.5; cursor:not-allowed; pointer-events:none;` | En `&:disabled { @include disabled; }` |
+| `@include tarjeta-base` | Tarjeta con padding/border/radius del proyecto | |
+| `@include tarjeta-interactiva` | Tarjeta + hover + focus-within | `.mi-tarjeta { @include tarjeta-interactiva; }` |
+| `@include glass($fondo)` | Backdrop-filter blur (efecto vidrio) | |
+| `@include enlace-subrayado` | Subrayado animado en hover/foco | |
+
+## Funciones disponibles (`01-tools/_funciones.scss`)
+
+Las funciones devuelven un **valor**: a diferencia de los mixins, no inyectan reglas CSS sino que se usan como literal en una declaración.
+
+| Función | Devuelve | Ejemplo |
+|---|---|---|
+| `rem($px)` | Píxeles → `rem` (base 16) | `padding: rem(24);` → `1.5rem` |
+| `em($px, $contexto: 16)` | Píxeles → `em` respecto a un contexto | `padding: em(12, 14);` |
+| `tomar($mapa, $clave)` | Acceso seguro a mapa Sass (error si falta) | `color: tomar($colores, primario);` |
+| `fluido($min, $max, $vp-min, $vp-max)` | `clamp()` lineal entre dos viewports | `font-size: fluido(2.5rem, 4.5rem);` |
+| `token-color($nombre)` | `var(--$nombre)` | `color: token-color(texto-claro);` |
+| `token-espacio($nivel)` | `var(--spacing-size-$nivel)` | `padding: token-espacio(2xl);` |
+| `token-radio($nivel)` | `var(--radius-$nivel)` | `border-radius: token-radio(l);` |
+| `token-sombra($nivel)` | `var(--shadow-$nivel)` | `box-shadow: token-sombra(md);` |
+| `token-z($capa)` | `var(--z-$capa)` | `z-index: token-z(modal);` |
+| `token-duracion($vel)` | `var(--duration-$vel)` | `transition-duration: token-duracion(base);` |
+| `contraste-sobre($color)` | Negro u oscuro según luminosidad del fondo | `color: contraste-sobre($fondo);` |
+
+## Cuándo crear mixin vs función vs utility
+
+- **Mixin** (`@mixin`): cuando reutilizas un **bloque de declaraciones CSS** (o quieres aceptar `@content`). Ej: media queries (`@include movil { ... }`), patrones (`@include flex-centro`), efectos (`@include glass`).
+- **Función** (`@function`): cuando reutilizas un **cálculo o valor derivado**. Ej: convertir unidades (`rem(24)`), generar `clamp()` fluido (`fluido(2.5rem, 4.5rem)`).
+- **Utility** (`.u-*` en `06-utilities/`): cuando reutilizas una regla directamente desde HTML. Ej: `<a class="u-saltar-contenido">`, `<section class="u-flex-centro">`.
+
+Una regla sencilla:
+
+> Si lo usas en SCSS y necesita `@content` o varias propiedades → mixin.
+> Si lo usas en SCSS y devuelve un solo valor → función.
+> Si lo usas en HTML sin modificar el componente → utility.
+
+## Estados obligatorios por tipo de componente
+
+Cada componente interactivo debe definir explícitamente sus estados. Los lectores de pantalla y la navegación por teclado dependen de esto.
+
+| Componente | Estados mínimos | Notas |
+|---|---|---|
+| Botón (`button`, `<a class="boton">`) | `:hover`, `:active`, `:focus-visible`, `:disabled` | `:focus-visible` para el outline, no `:focus` (que también se activa con ratón) |
+| Input / textarea / select | `:focus`, `:focus-visible`, `:disabled`, `:invalid:not(:focus)` | Mostrar borde rojo en `:invalid` sólo cuando el campo NO está enfocado |
+| Tarjeta / fila clickable | `:hover`, `:active`, `:focus-within` | `:focus-within` porque el foco lo reciben los elementos hijos (links/buttons), no la tarjeta |
+| Item de navegación | `:hover`, `:focus-visible`, `[aria-current="page"]` | `aria-current` lo aplica el router en runtime |
+| Enlace | `:hover`, `:focus-visible` | + `&::after` con subrayado animado si es un enlace destacado |
+| Modal / overlay | `:focus-within`, focus trap por JS | + `aria-modal="true"` y `role="dialog"` en HTML |
+
+## Responsive: estrategias usadas en el proyecto
+
+El proyecto **combina varios enfoques** intencionadamente para mostrar dominio de las herramientas:
+
+1. **Mobile-first con mixins** (la mayoría): `@include movil { ... }` cuando el breakpoint coincide con uno del sistema (576/768/992/1200/1400). Centralizado en `_mixins.scss`.
+2. **`@media` directo con Sass var** (excepción justificada): cuando el bloque está a nivel raíz (no anidado bajo un selector, p.ej. `_banner-cookies.scss`) o usa un breakpoint específico distinto al del sistema (`960px`, `720px`, `60rem`, `56.25rem`, `36rem`).
+3. **Tipografía fluida con `fluido()`** (`01-tools/_funciones.scss`): genera un `clamp()` que escala entre dos viewports sin necesidad de breakpoints. Se usa en hero (`_seccion-bienvenida.scss`) y títulos principales.
+4. **`clamp()` manual** (puntual): cuando el valor es muy específico y no se reutiliza, mantener `clamp(...)` directo es más claro que envolverlo en `fluido()`.
+5. **Container queries con `@container`**: en `_tarjeta-servidor.scss` y `_tarjeta-estadistica.scss`. El componente se adapta al ancho del contenedor (sidebar, grid, panel detalle, modal), no del viewport. Requiere `container-type: inline-size; container-name: ...;` en el bloque raíz.
+6. **Imágenes responsive con `<picture>`/`srcset`/`sizes`/`loading="lazy"`**: en las imágenes informativas con varias variantes y en above-the-fold con `width`/`height` declarados para evitar layout shift.
+
+## Accesibilidad: checklist WCAG aplicado
+
+El proyecto apunta a **WCAG 2.1 nivel AA**. Lista de mecanismos aplicados:
+
+- **HTML semántico**: `<header>`, `<main>`, `<nav>`, `<aside>`, `<footer>`, `<section aria-labelledby>`, `<article>`. Sin `<div>` para envolver contenido semántico.
+- **Landmarks etiquetados**: cada `<nav>` y `<section>` sin heading visible lleva `aria-label` o `aria-labelledby`.
+- **Skip link**: `.u-saltar-contenido` como primer foco al cargar la página; salta al `<main id="contenido-principal" tabindex="-1">`.
+- **`aria-current="page"`**: en cada item del sidebar y barra-pie cuando coincide con la ruta activa (`routerLinkActive` + `[attr.aria-current]`).
+- **Foco visible**: `:focus-visible` en todos los interactivos con outline amarillo 2px y offset 2px. Nunca se anula sin alternativa.
+- **`prefers-reduced-motion`**: `@include movimiento-reducido` en `_animaciones.scss` desactiva `.animar`, `.animar-hijos`, `.revelar`, `.aparecer` y limita `*` a 0.01ms.
+- **`prefers-color-scheme`**: el `ThemeService` aplica automáticamente el tema del sistema al primer arranque y se sincroniza con cambios del SO mientras el usuario no haya elegido manualmente.
+- **Contraste**: paleta diseñada con WCAG AA (texto principal sobre fondo ≥ 4.5:1). Verificado con WebAIM Contrast Checker / Stark.
+- **Imágenes**: `alt` significativo en informativas; `alt=""` + `aria-hidden="true"` en decorativas.
+- **Iconos**: FontAwesome y SVG decorativos con `aria-hidden="true"`; los que actúan solos llevan `aria-label` en el `<button>`/`<a>` padre.
+- **Formularios**: cada `<input>` con su `<label>` (asociado por wrapping o `for/id`), `:invalid` con feedback visual, `<fieldset>` + `<legend>` cuando el grupo es semánticamente relacionado.
 
 ## Convenciones BEM
 
@@ -61,20 +166,27 @@ El error contrario también es común: justificar el orden de carga de Settings 
   }
   ```
 
-- **Orden canónico** dentro del bloque raíz: propiedades → elementos `&__x` → modificadores `&--x` → estados `:hover/:focus/:focus-within` → media queries.
+- **Orden canónico** dentro del bloque raíz: propiedades → elementos `&__x` → modificadores `&--x` → estados `:hover/:focus-visible/:active/:focus-within` → container/media queries.
 - **Nombres en español** consistentes con el resto del proyecto.
-- **Prefijo `.u-`** para utilidades (`.u-oculto`, `.u-mt-l`).
-- **Sin `!important`**. Si una utility no gana al componente es que el orden de capas está mal.
-- **Sin anidamiento profundo** (>3 niveles); cada elemento BEM va anidado bajo el bloque raíz directamente, no como descendiente combinado.
+- **Prefijo `.u-`** para utilidades (`.u-flex-centro`, `.u-saltar-contenido`).
+- **Sin `!important`**, salvo en `@include movimiento-reducido` (preferencia del usuario que debe ganar). Si una utility no gana al componente es que el orden de capas está mal.
+- **Sin anidamiento profundo** (>3 niveles); cada elemento BEM va anidado bajo el bloque raíz directamente.
 - **Mobile first** con `@mixin movil`, `@mixin tablet`, `@mixin escritorio` desde `01-tools/_mixins.scss`.
 
-## Estados interactivos
-
-Cada componente con interacción real debe definir explícitamente sus estados usando las variables `--*-hover` del design tokens (`--amarillo-normal-hover`, etc.):
+## Estados interactivos: ejemplo completo
 
 ```scss
+@use "../01-tools/mixins" as *;
+
 .tarjeta-servidor {
-  transition: transform var(--duration-base), box-shadow var(--duration-base), border-color var(--duration-base);
+  container-type: inline-size;
+  @include tarjeta-base;
+  @include transicion(transform, box-shadow, border-color);
+
+  &__cabecera { /* ... */ }
+  &__metricas { /* ... */ }
+
+  &--destacada { border-color: var(--amarillo-normal); }
 
   &:hover {
     transform: translateY(-0.125rem);
@@ -82,14 +194,25 @@ Cada componente con interacción real debe definir explícitamente sus estados u
     border-color: var(--amarillo-normal-hover);
   }
 
+  &:active {
+    transform: translateY(0);
+    box-shadow: var(--shadow-sm);
+  }
+
   &:focus-within {
     outline: 2px solid var(--amarillo-normal);
     outline-offset: 2px;
   }
+
+  @include contenedor-pequeno {
+    &__ip { display: none; }
+  }
+
+  @include contenedor-grande {
+    &__metricas { display: grid; grid-template-columns: repeat(2, 1fr); }
+  }
 }
 ```
-
-Estados obligatorios para accesibilidad: `:hover` (cursor), `:focus-visible` o `:focus-within` (teclado). Sin esto, los usuarios de teclado no ven dónde está el foco.
 
 ## Páginas: patrón estándar
 
@@ -107,9 +230,10 @@ Cada página Angular sigue este patrón:
 ## Cómo añadir una página nueva
 
 1. Crear `src/styles/05-components/_pagina-foo.scss` con un bloque BEM `.pagina-foo` y anidamiento con `&__elemento` y `&--modificador`.
-2. Añadir `@use "styles/05-components/pagina-foo";` en `styles.scss`.
-3. Crear `src/app/pages/foo/foo.scss` con solo un comentario `// Estilos en styles/05-components/_pagina-foo.scss`.
-4. En `@Component`, apuntar `styleUrl: "./foo.scss"` para que Angular no se queje.
+2. Si vas a usar mixins o funciones, añadir al inicio `@use "../01-tools/mixins" as *;` y/o `@use "../01-tools/funciones" as *;`.
+3. Añadir `@use "styles/05-components/pagina-foo";` en `styles.scss`.
+4. Crear `src/app/pages/foo/foo.scss` con solo un comentario `// Estilos en styles/05-components/_pagina-foo.scss`.
+5. En `@Component`, apuntar `styleUrl: "./foo.scss"` para que Angular no se queje.
 
 ## Cómo añadir un componente compartido
 
@@ -119,6 +243,6 @@ Cada página Angular sigue este patrón:
 
 ## Cómo añadir una utilidad
 
-1. Decidir si encaja en visibilidad / texto / espaciados o crear archivo nuevo en `06-utilities/`.
+1. Decidir si encaja en visibilidad / texto / espaciados / flex / display / z-index / saltar-contenido o crear archivo nuevo en `06-utilities/`.
 2. Si es archivo nuevo, registrarlo en `styles.scss` dentro de `// 06 · Utilities`.
 3. Usar prefijo `.u-` y nombre descriptivo en español.


### PR DESCRIPTION
## Resumen

Reescritura del `src/styles/README.md` para documentar:

- **25+ mixins** (responsive, container queries, preferencias de usuario, layout flex, accesibilidad, componentes base, efectos) con tabla, propósito y ejemplo de uso.
- **11 funciones** Sass (`rem`, `em`, `fluido`, `tomar`, `token-color`, `token-espacio`, `token-radio`, `token-sombra`, `token-z`, `token-duracion`, `contraste-sobre`) con valor devuelto y ejemplo.
- **Cuándo crear mixin vs función vs utility** con regla resumida.
- **Estados obligatorios por tipo de componente** (botón, input, tarjeta, item navegación, enlace, modal).
- **6 estrategias responsive** del proyecto: mixins, `@media` directo con Sass var, `fluido()`, `clamp()` manual, container queries, `<picture>`/srcset.
- **Checklist WCAG 2.1 AA aplicado**: landmarks etiquetados, skip link, `aria-current`, `prefers-reduced-motion`, `prefers-color-scheme`, contraste, imágenes, iconos, formularios.
- **Ejemplo de bloque BEM completo** con estados + container queries para servir de referencia.

## Por qué importa

Es el documento que el evaluador puede leer en una sola pasada para entender la arquitectura sin abrir ningún `.scss`. Concentra en un solo archivo la disciplina arquitectónica, la cobertura de preprocesadores y las decisiones responsive y de accesibilidad.

## Test plan

- [x] Lectura en GitHub web → render Markdown correcto.
- [ ] Sirve para defensa: el alumno puede explicar el proyecto leyendo este archivo.