### PR TITLE
feat(styles): container query en .tarjeta-plan y fix import de mixins

### DIFF
--- a/autodeploy/public/i18n/de.json
+++ b/autodeploy/public/i18n/de.json
@@ -101,7 +101,10 @@
       "temaOscuro": "Dunklen Modus aktivieren",
       "notificaciones": "Benachrichtigungen",
       "menu": "Menü öffnen",
-      "cerrarMenu": "Menü schließen"
+      "cerrarMenu": "Menü schließen",
+      "acciones": "Header-Aktionen",
+      "zonaNotificaciones": "Benachrichtigungsbereich",
+      "panelMovilPortal": "Mobiles Menü"
     },
     "dropdown": {
       "titulo": "Benachrichtigungen",
@@ -1008,7 +1011,7 @@
     "ctaPrincipal": "Regel hinzufügen",
     "ctaSecundario": "Port öffnen oder blockieren",
     "selectorServidor": "Zielserver",
-    "presetsEtiqueta": "Voreinstellungen · mit einem Klick",
+    "presetsEtiqueta": "Mit einem Klick einrichten",
     "presetSsh": "SSH",
     "presetHttp": "HTTP",
     "presetHttps": "HTTPS",

--- a/autodeploy/public/i18n/de.json
+++ b/autodeploy/public/i18n/de.json
@@ -17,6 +17,11 @@
     "buscar": "Suchen",
     "guion": "—",
     "menu": "Menü",
+    "saltarContenido": "Zum Inhalt springen",
+    "cerrarMenu": "Menü schließen",
+    "ariaDisposicionApp": "AutoDeploy-Anwendung",
+    "ariaCabeceraMovil": "Mobiler Header",
+    "ariaContenidoApp": "Hauptinhalt der Anwendung",
     "sinDatos": "Noch keine Daten",
     "guardando": "Wird gespeichert…",
     "guardado": "Gespeichert",
@@ -74,7 +79,12 @@
       "contacto": "Kontakt",
       "comunidad": "Community"
     },
-    "copyright": "© 2026 AutoDeployService · Unternehmens-Cloud-Infrastruktur"
+    "copyright": "© 2026 AutoDeployService · Unternehmens-Cloud-Infrastruktur",
+    "ariaContenido": "Footer-Informationen und Links",
+    "ariaMarca": "Über AutoDeployService",
+    "ariaInferior": "Copyright und allgemeine Einstellungen",
+    "ariaAjustes": "Sprache und soziale Netzwerke",
+    "ariaRedes": "Soziale Netzwerke"
   },
   "barraPie": {
     "estado": "Alle Systeme betriebsbereit",
@@ -135,7 +145,11 @@
     },
     "chipPro": "Pro",
     "colapsar": "Einklappen",
-    "fallbackCuenta": "Mein Konto"
+    "fallbackCuenta": "Mein Konto",
+    "ariaPrincipal": "Seitenleiste der Anwendung",
+    "ariaNavegacion": "Hauptnavigation",
+    "ariaColapsar": "Seitenleiste einklappen oder ausklappen",
+    "ariaInfoUsuario": "Kontoinformationen"
   },
   "bannerCookies": {
     "texto": "Wir verwenden eigene Cookies, um Ihre Erfahrung zu verbessern. Lesen Sie unsere",
@@ -713,7 +727,7 @@
       "authMethodContrasena": "Passwort",
       "clavePlaceholder": "Geben Sie das Server-Passwort ein",
       "claveSsh": "Privater SSH-Schlüssel",
-      "claveSshPlaceholder": "-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----",
+      "claveSshPlaceholder": "Privaten Schlüssel hier einfügen (OpenSSH-Format, BEGIN/END-Zeilen einschließen)",
       "claveSshPista": "Fügen Sie den vollständigen Inhalt Ihres privaten Schlüssels ein, einschließlich der Zeilen BEGIN und END."
     },
     "ayuda": {

--- a/autodeploy/public/i18n/en.json
+++ b/autodeploy/public/i18n/en.json
@@ -101,7 +101,10 @@
       "temaOscuro": "Switch to dark mode",
       "notificaciones": "Notifications",
       "menu": "Open menu",
-      "cerrarMenu": "Close menu"
+      "cerrarMenu": "Close menu",
+      "acciones": "Header actions",
+      "zonaNotificaciones": "Notifications area",
+      "panelMovilPortal": "Mobile menu"
     },
     "dropdown": {
       "titulo": "Notifications",
@@ -1008,7 +1011,7 @@
     "ctaPrincipal": "Add rule",
     "ctaSecundario": "Open or block a port",
     "selectorServidor": "Target server",
-    "presetsEtiqueta": "Presets · one click",
+    "presetsEtiqueta": "Set up in one click",
     "presetSsh": "SSH",
     "presetHttp": "HTTP",
     "presetHttps": "HTTPS",

--- a/autodeploy/public/i18n/en.json
+++ b/autodeploy/public/i18n/en.json
@@ -17,6 +17,11 @@
     "buscar": "Search",
     "guion": "—",
     "menu": "Menu",
+    "saltarContenido": "Skip to content",
+    "cerrarMenu": "Close menu",
+    "ariaDisposicionApp": "AutoDeploy application",
+    "ariaCabeceraMovil": "Mobile header",
+    "ariaContenidoApp": "Main application content",
     "sinDatos": "No data yet",
     "guardando": "Saving…",
     "guardado": "Saved",
@@ -74,7 +79,12 @@
       "contacto": "Contact",
       "comunidad": "Community"
     },
-    "copyright": "© 2026 AutoDeployService · Enterprise cloud infrastructure"
+    "copyright": "© 2026 AutoDeployService · Enterprise cloud infrastructure",
+    "ariaContenido": "Footer information and links",
+    "ariaMarca": "About AutoDeployService",
+    "ariaInferior": "Copyright and general settings",
+    "ariaAjustes": "Language and social networks",
+    "ariaRedes": "Social networks"
   },
   "barraPie": {
     "estado": "All systems operational",
@@ -135,7 +145,11 @@
     },
     "chipPro": "Pro",
     "colapsar": "Collapse",
-    "fallbackCuenta": "My account"
+    "fallbackCuenta": "My account",
+    "ariaPrincipal": "Application sidebar",
+    "ariaNavegacion": "Main navigation",
+    "ariaColapsar": "Collapse or expand sidebar",
+    "ariaInfoUsuario": "Account information"
   },
   "bannerCookies": {
     "texto": "We use first-party cookies to improve your experience. Read our",
@@ -713,7 +727,7 @@
       "authMethodContrasena": "Password",
       "clavePlaceholder": "Enter the server password",
       "claveSsh": "SSH private key",
-      "claveSshPlaceholder": "-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----",
+      "claveSshPlaceholder": "Paste your private key here (OpenSSH format, BEGIN/END lines included)",
       "claveSshPista": "Paste the full contents of your private key, including the BEGIN and END lines."
     },
     "ayuda": {

--- a/autodeploy/public/i18n/es.json
+++ b/autodeploy/public/i18n/es.json
@@ -101,7 +101,10 @@
       "temaOscuro": "Activar modo oscuro",
       "notificaciones": "Notificaciones",
       "menu": "Abrir menú",
-      "cerrarMenu": "Cerrar menú"
+      "cerrarMenu": "Cerrar menú",
+      "acciones": "Acciones de la cabecera",
+      "zonaNotificaciones": "Zona de notificaciones",
+      "panelMovilPortal": "Menú móvil"
     },
     "dropdown": {
       "titulo": "Notificaciones",
@@ -1008,7 +1011,7 @@
     "ctaPrincipal": "Añadir regla",
     "ctaSecundario": "Abrir o bloquear un puerto",
     "selectorServidor": "Servidor de destino",
-    "presetsEtiqueta": "Presets · un clic",
+    "presetsEtiqueta": "Configura en un click",
     "presetSsh": "SSH",
     "presetHttp": "HTTP",
     "presetHttps": "HTTPS",

--- a/autodeploy/public/i18n/es.json
+++ b/autodeploy/public/i18n/es.json
@@ -17,6 +17,11 @@
     "buscar": "Buscar",
     "guion": "—",
     "menu": "Menú",
+    "saltarContenido": "Saltar al contenido",
+    "cerrarMenu": "Cerrar menú",
+    "ariaDisposicionApp": "Aplicación AutoDeploy",
+    "ariaCabeceraMovil": "Cabecera móvil",
+    "ariaContenidoApp": "Contenido principal de la aplicación",
     "sinDatos": "Sin datos todavía",
     "guardando": "Guardando…",
     "guardado": "Guardado",
@@ -74,7 +79,12 @@
       "contacto": "Contacto",
       "comunidad": "Comunidad"
     },
-    "copyright": "© 2026 AutoDeployService · Infraestructura cloud empresarial"
+    "copyright": "© 2026 AutoDeployService · Infraestructura cloud empresarial",
+    "ariaContenido": "Información y enlaces del pie de página",
+    "ariaMarca": "Sobre AutoDeployService",
+    "ariaInferior": "Copyright y ajustes generales",
+    "ariaAjustes": "Idioma y redes sociales",
+    "ariaRedes": "Redes sociales"
   },
   "barraPie": {
     "estado": "Todos los sistemas operativos",
@@ -135,7 +145,11 @@
     },
     "chipPro": "Pro",
     "colapsar": "Colapsar",
-    "fallbackCuenta": "Mi cuenta"
+    "fallbackCuenta": "Mi cuenta",
+    "ariaPrincipal": "Barra lateral de la aplicación",
+    "ariaNavegacion": "Navegación principal",
+    "ariaColapsar": "Colapsar o expandir la barra lateral",
+    "ariaInfoUsuario": "Información de la cuenta"
   },
   "bannerCookies": {
     "texto": "Usamos cookies propias para mejorar tu experiencia. Consulta nuestra",
@@ -713,7 +727,7 @@
       "authMethodContrasena": "Contraseña",
       "clavePlaceholder": "Introduce la contraseña del servidor",
       "claveSsh": "Clave SSH privada",
-      "claveSshPlaceholder": "-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----",
+      "claveSshPlaceholder": "Pega aquí tu clave privada (formato OpenSSH, líneas BEGIN/END incluidas)",
       "claveSshPista": "Pega el contenido completo de tu clave privada, incluyendo las líneas BEGIN y END."
     },
     "ayuda": {

--- a/autodeploy/public/i18n/fr.json
+++ b/autodeploy/public/i18n/fr.json
@@ -101,7 +101,10 @@
       "temaOscuro": "Activer le mode sombre",
       "notificaciones": "Notifications",
       "menu": "Ouvrir le menu",
-      "cerrarMenu": "Fermer le menu"
+      "cerrarMenu": "Fermer le menu",
+      "acciones": "Actions de l'en-tête",
+      "zonaNotificaciones": "Zone des notifications",
+      "panelMovilPortal": "Menu mobile"
     },
     "dropdown": {
       "titulo": "Notifications",
@@ -1008,7 +1011,7 @@
     "ctaPrincipal": "Ajouter une règle",
     "ctaSecundario": "Ouvrir ou bloquer un port",
     "selectorServidor": "Serveur de destination",
-    "presetsEtiqueta": "Préréglages · en un clic",
+    "presetsEtiqueta": "Configurez en un clic",
     "presetSsh": "SSH",
     "presetHttp": "HTTP",
     "presetHttps": "HTTPS",

--- a/autodeploy/public/i18n/fr.json
+++ b/autodeploy/public/i18n/fr.json
@@ -17,6 +17,11 @@
     "buscar": "Rechercher",
     "guion": "—",
     "menu": "Menu",
+    "saltarContenido": "Aller au contenu",
+    "cerrarMenu": "Fermer le menu",
+    "ariaDisposicionApp": "Application AutoDeploy",
+    "ariaCabeceraMovil": "En-tête mobile",
+    "ariaContenidoApp": "Contenu principal de l'application",
     "sinDatos": "Aucune donnée pour le moment",
     "guardando": "Enregistrement…",
     "guardado": "Enregistré",
@@ -74,7 +79,12 @@
       "contacto": "Contact",
       "comunidad": "Communauté"
     },
-    "copyright": "© 2026 AutoDeployService · Infrastructure cloud d'entreprise"
+    "copyright": "© 2026 AutoDeployService · Infrastructure cloud d'entreprise",
+    "ariaContenido": "Informations et liens du pied de page",
+    "ariaMarca": "À propos d'AutoDeployService",
+    "ariaInferior": "Copyright et réglages généraux",
+    "ariaAjustes": "Langue et réseaux sociaux",
+    "ariaRedes": "Réseaux sociaux"
   },
   "barraPie": {
     "estado": "Tous les systèmes opérationnels",
@@ -135,7 +145,11 @@
     },
     "chipPro": "Pro",
     "colapsar": "Réduire",
-    "fallbackCuenta": "Mon compte"
+    "fallbackCuenta": "Mon compte",
+    "ariaPrincipal": "Barre latérale de l'application",
+    "ariaNavegacion": "Navigation principale",
+    "ariaColapsar": "Réduire ou agrandir la barre latérale",
+    "ariaInfoUsuario": "Informations du compte"
   },
   "bannerCookies": {
     "texto": "Nous utilisons des cookies propriétaires pour améliorer votre expérience. Consultez notre",
@@ -713,7 +727,7 @@
       "authMethodContrasena": "Mot de passe",
       "clavePlaceholder": "Saisissez le mot de passe du serveur",
       "claveSsh": "Clé SSH privée",
-      "claveSshPlaceholder": "-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----",
+      "claveSshPlaceholder": "Collez ici votre clé privée (format OpenSSH, lignes BEGIN/END incluses)",
       "claveSshPista": "Collez le contenu complet de votre clé privée, y compris les lignes BEGIN et END."
     },
     "ayuda": {

--- a/autodeploy/public/i18n/it.json
+++ b/autodeploy/public/i18n/it.json
@@ -17,6 +17,11 @@
     "buscar": "Cerca",
     "guion": "—",
     "menu": "Menu",
+    "saltarContenido": "Vai al contenuto",
+    "cerrarMenu": "Chiudi menu",
+    "ariaDisposicionApp": "Applicazione AutoDeploy",
+    "ariaCabeceraMovil": "Intestazione mobile",
+    "ariaContenidoApp": "Contenuto principale dell'applicazione",
     "sinDatos": "Nessun dato ancora",
     "guardando": "Salvataggio…",
     "guardado": "Salvato",
@@ -74,7 +79,12 @@
       "contacto": "Contatti",
       "comunidad": "Community"
     },
-    "copyright": "© 2026 AutoDeployService · Infrastruttura cloud aziendale"
+    "copyright": "© 2026 AutoDeployService · Infrastruttura cloud aziendale",
+    "ariaContenido": "Informazioni e link del piè di pagina",
+    "ariaMarca": "Su AutoDeployService",
+    "ariaInferior": "Copyright e impostazioni generali",
+    "ariaAjustes": "Lingua e social network",
+    "ariaRedes": "Social network"
   },
   "barraPie": {
     "estado": "Tutti i sistemi operativi",
@@ -135,7 +145,11 @@
     },
     "chipPro": "Pro",
     "colapsar": "Comprimi",
-    "fallbackCuenta": "Il mio account"
+    "fallbackCuenta": "Il mio account",
+    "ariaPrincipal": "Barra laterale dell'applicazione",
+    "ariaNavegacion": "Navigazione principale",
+    "ariaColapsar": "Comprimi o espandi la barra laterale",
+    "ariaInfoUsuario": "Informazioni dell'account"
   },
   "bannerCookies": {
     "texto": "Utilizziamo cookie propri per migliorare la tua esperienza. Consulta la nostra",
@@ -713,7 +727,7 @@
       "authMethodContrasena": "Password",
       "clavePlaceholder": "Inserisci la password del server",
       "claveSsh": "Chiave SSH privata",
-      "claveSshPlaceholder": "-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----",
+      "claveSshPlaceholder": "Incolla qui la tua chiave privata (formato OpenSSH, righe BEGIN/END incluse)",
       "claveSshPista": "Incolla l'intero contenuto della tua chiave privata, incluse le righe BEGIN e END."
     },
     "ayuda": {

--- a/autodeploy/public/i18n/it.json
+++ b/autodeploy/public/i18n/it.json
@@ -101,7 +101,10 @@
       "temaOscuro": "Attiva modalità scura",
       "notificaciones": "Notifiche",
       "menu": "Apri menu",
-      "cerrarMenu": "Chiudi menu"
+      "cerrarMenu": "Chiudi menu",
+      "acciones": "Azioni dell'intestazione",
+      "zonaNotificaciones": "Area notifiche",
+      "panelMovilPortal": "Menu mobile"
     },
     "dropdown": {
       "titulo": "Notifiche",
@@ -1008,7 +1011,7 @@
     "ctaPrincipal": "Aggiungi regola",
     "ctaSecundario": "Apri o blocca una porta",
     "selectorServidor": "Server di destinazione",
-    "presetsEtiqueta": "Preset · un clic",
+    "presetsEtiqueta": "Configura in un click",
     "presetSsh": "SSH",
     "presetHttp": "HTTP",
     "presetHttps": "HTTPS",

--- a/autodeploy/public/img/capturas/README.md
+++ b/autodeploy/public/img/capturas/README.md
@@ -1,0 +1,68 @@
+# Capturas del producto
+
+Esta carpeta aloja las imágenes que la galería accesible (`app-galeria-capturas`) consume desde la página de Style Guide y, en el futuro, desde la sección de bienvenida.
+
+## Formato y tamaños
+
+Generar cada captura en **dos variantes WebP** (con un fallback JPG opcional para navegadores muy antiguos):
+
+| Variante | Resolución | Densidad | Uso |
+|---|---|---|---|
+| Mobile | 800 × 500 px | 1× | `<source media="(max-width: 48rem)" srcset>` |
+| Desktop | 1600 × 1000 px | 2× | `<source srcset>` por defecto |
+
+Cada archivo debe pesar **menos de 200 KB**. Recomendado: optimizar con [Squoosh](https://squoosh.app/) (calidad ~75% WebP).
+
+## Convención de nombres
+
+```
+<nombre-de-pantalla>-mobile.webp     · 800 × 500
+<nombre-de-pantalla>-desktop.webp    · 1600 × 1000
+<nombre-de-pantalla>-fallback.jpg    · 800 × 500 (opcional)
+```
+
+Ejemplo:
+
+```
+dashboard-mobile.webp
+dashboard-desktop.webp
+dashboard-fallback.jpg
+
+asistente-ia-mobile.webp
+asistente-ia-desktop.webp
+
+terminal-mobile.webp
+terminal-desktop.webp
+```
+
+## Cómo usarlas en la galería
+
+En `autodeploy/src/app/pages/style-guide/style-guide.ts` (u otra página padre que renderice `<app-galeria-capturas>`):
+
+```typescript
+capturasDemo: Captura[] = [
+  {
+    src: "/img/capturas/dashboard-desktop.webp",
+    srcMovil: "/img/capturas/dashboard-mobile.webp",
+    fallback: "/img/capturas/dashboard-fallback.jpg",
+    alt: "Panel principal con tres servidores activos y métricas en vivo (CPU 24%, RAM 58%, disco 42%)",
+    titulo: "Panel principal con métricas en tiempo real",
+    ancho: 1600,
+    alto: 1000,
+  },
+  // ... otras 5
+];
+```
+
+El componente genera automáticamente `<picture>` con `<source media>` + `<img loading="lazy">` + `<figure>` + `<figcaption>`.
+
+## Alt descriptivo
+
+El `alt` debe describir **la información que aporta la imagen**, no su apariencia. Buenos ejemplos:
+
+- ✅ "Panel principal con tres servidores activos y métricas en vivo"
+- ✅ "Terminal SSH conectada con prompt root@vps-prod-01 listo para recibir comandos"
+- ❌ "Captura del panel"
+- ❌ "Imagen de un dashboard"
+
+Si una captura es puramente decorativa (poco probable en este caso), usar `alt=""` y ya está.

--- a/autodeploy/src/app/app.routes.ts
+++ b/autodeploy/src/app/app.routes.ts
@@ -58,6 +58,11 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./pages/comunidad/comunidad').then((modulo) => modulo.Comunidad),
       },
+      {
+        path: 'style-guide',
+        loadComponent: () =>
+          import('./pages/style-guide/style-guide').then((modulo) => modulo.StyleGuide),
+      },
     ],
   },
   {

--- a/autodeploy/src/app/components/layout/app-layout/app-layout.html
+++ b/autodeploy/src/app/components/layout/app-layout/app-layout.html
@@ -1,21 +1,23 @@
-<section class="disposicion-app">
-  <header class="disposicion-app__cabecera-movil">
+<section class="disposicion-app" [attr.aria-label]="'comun.ariaDisposicionApp' | translate">
+  <a class="u-saltar-contenido" href="#contenido-principal">{{ "comun.saltarContenido" | translate }}</a>
+
+  <header class="disposicion-app__cabecera-movil" [attr.aria-label]="'comun.ariaCabeceraMovil' | translate">
     <button class="disposicion-app__hamburguesa" (click)="alternarSidebar()" [attr.aria-label]="'comun.menu' | translate">
-      <i class="fa-solid fa-bars"></i>
+      <i class="fa-solid fa-bars" aria-hidden="true"></i>
     </button>
     <a class="disposicion-app__logo-movil" routerLink="/">
-      <img class="disposicion-app__logo-movil__imagen" src="logo.png" alt="">
-      <span class="disposicion-app__logo-movil__texto">Auto<span class="disposicion-app__logo-movil__texto--acento">Deploy</span></span>
+      <img class="disposicion-app__logo-movil__imagen" src="logo.png" alt="AutoDeploy">
+      <span class="disposicion-app__logo-movil__texto" aria-hidden="true">Auto<span class="disposicion-app__logo-movil__texto--acento">Deploy</span></span>
     </a>
     <app-campana-notificaciones></app-campana-notificaciones>
   </header>
 
-  <section class="disposicion-app__backdrop" [class.disposicion-app__backdrop--visible]="sidebarAbierta()" (click)="cerrarSidebar()"></section>
+  <button type="button" class="disposicion-app__backdrop" [class.disposicion-app__backdrop--visible]="sidebarAbierta()" (click)="cerrarSidebar()" [attr.aria-label]="'comun.cerrarMenu' | translate" tabindex="-1"></button>
 
   <app-sidebar [abierta]="sidebarAbierta()"></app-sidebar>
 
-  <section class="disposicion-app__contenido">
-    <main class="disposicion-app__principal">
+  <section class="disposicion-app__contenido" [attr.aria-label]="'comun.ariaContenidoApp' | translate">
+    <main id="contenido-principal" tabindex="-1" class="disposicion-app__principal">
       <router-outlet></router-outlet>
     </main>
     <app-barra-pie-app></app-barra-pie-app>

--- a/autodeploy/src/app/components/layout/app-layout/app-layout.html
+++ b/autodeploy/src/app/components/layout/app-layout/app-layout.html
@@ -6,7 +6,7 @@
       <i class="fa-solid fa-bars" aria-hidden="true"></i>
     </button>
     <a class="disposicion-app__logo-movil" routerLink="/">
-      <img class="disposicion-app__logo-movil__imagen" src="logo.png" alt="AutoDeploy">
+      <img class="disposicion-app__logo-movil__imagen" src="logo.png" alt="AutoDeploy" width="24" height="24">
       <span class="disposicion-app__logo-movil__texto" aria-hidden="true">Auto<span class="disposicion-app__logo-movil__texto--acento">Deploy</span></span>
     </a>
     <app-campana-notificaciones></app-campana-notificaciones>

--- a/autodeploy/src/app/components/layout/footer/footer.html
+++ b/autodeploy/src/app/components/layout/footer/footer.html
@@ -1,16 +1,16 @@
 <footer class="pie">
-  <section class="pie__linea-decorativa"></section>
+  <hr class="pie__linea-decorativa" aria-hidden="true">
 
-  <section class="pie__contenido">
-    <section class="pie__marca">
+  <section class="pie__contenido" [attr.aria-label]="'footer.ariaContenido' | translate">
+    <section class="pie__marca" [attr.aria-label]="'footer.ariaMarca' | translate">
       <p class="pie__marca__nombre">AutoDeployService</p>
       <p class="pie__marca__descripcion">{{ "footer.marca.descripcion1" | translate }}</p>
       <p class="pie__marca__descripcion">{{ "footer.marca.descripcion2" | translate }}</p>
       <p class="pie__marca__descripcion">{{ "footer.marca.descripcion3" | translate }}</p>
     </section>
 
-    <nav class="pie__columna">
-      <p class="pie__columna__titulo">{{ "footer.columnaProducto.titulo" | translate }}</p>
+    <nav class="pie__columna" [attr.aria-label]="'footer.columnaProducto.titulo' | translate">
+      <p class="pie__columna__titulo" aria-hidden="true">{{ "footer.columnaProducto.titulo" | translate }}</p>
       <ul class="pie__columna__lista">
         <li><a class="pie__columna__enlace" routerLink="/" fragment="features">{{ "footer.columnaProducto.features" | translate }}</a></li>
         <li><a class="pie__columna__enlace" routerLink="/" fragment="how-it-works">{{ "footer.columnaProducto.comoFunciona" | translate }}</a></li>
@@ -19,8 +19,8 @@
       </ul>
     </nav>
 
-    <nav class="pie__columna">
-      <p class="pie__columna__titulo">{{ "footer.columnaLegal.titulo" | translate }}</p>
+    <nav class="pie__columna" [attr.aria-label]="'footer.columnaLegal.titulo' | translate">
+      <p class="pie__columna__titulo" aria-hidden="true">{{ "footer.columnaLegal.titulo" | translate }}</p>
       <ul class="pie__columna__lista">
         <li><a class="pie__columna__enlace" routerLink="/politica-privacidad">{{ "footer.columnaLegal.politicaPrivacidad" | translate }}</a></li>
         <li><a class="pie__columna__enlace" routerLink="/aviso-legal">{{ "footer.columnaLegal.terminos" | translate }}</a></li>
@@ -29,8 +29,8 @@
       </ul>
     </nav>
 
-    <nav class="pie__columna">
-      <p class="pie__columna__titulo">{{ "footer.columnaSoporte.titulo" | translate }}</p>
+    <nav class="pie__columna" [attr.aria-label]="'footer.columnaSoporte.titulo' | translate">
+      <p class="pie__columna__titulo" aria-hidden="true">{{ "footer.columnaSoporte.titulo" | translate }}</p>
       <ul class="pie__columna__lista">
         <li><a class="pie__columna__enlace" routerLink="/documentacion">{{ "footer.columnaSoporte.documentacion" | translate }}</a></li>
         <li><a class="pie__columna__enlace" routerLink="/estado">{{ "footer.columnaSoporte.estado" | translate }}</a></li>
@@ -40,29 +40,29 @@
     </nav>
   </section>
 
-  <section class="pie__separador"></section>
+  <hr class="pie__separador" aria-hidden="true">
 
-  <section class="pie__inferior">
+  <section class="pie__inferior" [attr.aria-label]="'footer.ariaInferior' | translate">
     <p class="pie__inferior__copyright">{{ "footer.copyright" | translate }}</p>
-    <section class="pie__inferior__bloque-derecha">
+    <section class="pie__inferior__bloque-derecha" [attr.aria-label]="'footer.ariaAjustes' | translate">
       <app-selector-idioma modo="desplegable"></app-selector-idioma>
-      <section class="pie__inferior__redes">
+      <nav class="pie__inferior__redes" [attr.aria-label]="'footer.ariaRedes' | translate">
         <a class="pie__inferior__red" href="https://github.com" target="_blank" rel="noopener" aria-label="GitHub">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
           </svg>
         </a>
-        <a class="pie__inferior__red" href="https://x.com" target="_blank" rel="noopener" aria-label="X Twitter">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+        <a class="pie__inferior__red" href="https://x.com" target="_blank" rel="noopener" aria-label="X (antes Twitter)">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>
         </a>
         <a class="pie__inferior__red" href="https://instagram.com" target="_blank" rel="noopener" aria-label="Instagram">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 1 0 0 12.324 6.162 6.162 0 0 0 0-12.324zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.406-11.845a1.44 1.44 0 1 0 0 2.881 1.44 1.44 0 0 0 0-2.881z"/>
           </svg>
         </a>
-      </section>
+      </nav>
     </section>
   </section>
 </footer>

--- a/autodeploy/src/app/components/layout/footer/footer.scss
+++ b/autodeploy/src/app/components/layout/footer/footer.scss
@@ -7,6 +7,8 @@
 
 .pie__linea-decorativa {
   height: 1px;
+  border: 0;
+  margin: 0;
   background: var(--borde-normal);
 }
 
@@ -67,6 +69,8 @@
 
 .pie__separador {
   height: 1px;
+  border: 0;
+  margin: 0;
   background-color: var(--borde-normal);
 }
 

--- a/autodeploy/src/app/components/layout/header/header.html
+++ b/autodeploy/src/app/components/layout/header/header.html
@@ -12,7 +12,7 @@
     </ul>
   </nav>
 
-  <section class="cabecera__acciones">
+  <menu class="cabecera__acciones" [attr.aria-label]="'header.aria.acciones' | translate">
     <button type="button" class="cabecera__tema" (click)="themeService.alternarTema()" [attr.aria-label]="themeService.temaActual() === 'oscuro' ? ('header.aria.temaClaro' | translate) : ('header.aria.temaOscuro' | translate)">
       @if (themeService.temaActual() === 'oscuro') {
         <i class="fa-solid fa-sun"></i>
@@ -22,7 +22,7 @@
     </button>
 
     @if (authService.estaLogueado()) {
-      <section class="cabecera__notificaciones">
+      <section class="cabecera__notificaciones" [attr.aria-label]="'header.aria.zonaNotificaciones' | translate">
         <button type="button" class="cabecera__campana" (click)="alternarNotificaciones()" [attr.aria-label]="'header.aria.notificaciones' | translate">
           <i class="fa-solid fa-bell"></i>
           @if (contadorSinLeer() > 0) {
@@ -82,11 +82,11 @@
         <span class="cabecera__hamburguesa__punto" aria-hidden="true"></span>
       }
     </button>
-  </section>
+  </menu>
 </header>
 
 @if (menuMovilAbierto()) {
-  <section class="cabecera__panel-movil-portal">
+  <aside class="cabecera__panel-movil-portal" [attr.aria-label]="'header.aria.panelMovilPortal' | translate">
     <section class="cabecera__panel-movil" role="dialog" aria-modal="true" aria-labelledby="titulo-panel-movil">
       <header class="cabecera__panel-movil__cabecera">
         <span class="cabecera__panel-movil__titulo" id="titulo-panel-movil">{{ "header.panelMovil.titulo" | translate }}</span>
@@ -102,9 +102,9 @@
       </nav>
 
       @if (authService.estaLogueado() && listaNotificaciones().length > 0) {
-        <section class="cabecera__panel-movil__notificaciones">
+        <section class="cabecera__panel-movil__notificaciones" aria-labelledby="panel-movil-notif-titulo">
           <header class="cabecera__panel-movil__notif-cabecera">
-            <span class="cabecera__panel-movil__notif-titulo">{{ "header.dropdown.titulo" | translate }}</span>
+            <span class="cabecera__panel-movil__notif-titulo" id="panel-movil-notif-titulo">{{ "header.dropdown.titulo" | translate }}</span>
             @if (contadorSinLeer() > 0) {
               <button class="cabecera__panel-movil__notif-marcar" (click)="marcarTodasComoLeidas()">
                 {{ "header.dropdown.marcarTodas" | translate }}
@@ -122,7 +122,7 @@
         </section>
       }
 
-      <section class="cabecera__panel-movil__pie">
+      <footer class="cabecera__panel-movil__pie">
         @if (authService.estaLogueado()) {
           <a class="cabecera__panel-movil__cta-secundaria" routerLink="/app/cuenta" (click)="cerrarMenuMovil()">
             <i class="fa-solid fa-user"></i>
@@ -137,8 +137,8 @@
         <a class="cabecera__panel-movil__cta-primaria" routerLink="/app" (click)="cerrarMenuMovil()">
           {{ "header.botonApp" | translate }}
         </a>
-      </section>
+      </footer>
     </section>
-    <button class="cabecera__panel-movil__velo" (click)="cerrarMenuMovil()" aria-hidden="true" tabindex="-1"></button>
-  </section>
+    <button class="cabecera__panel-movil__velo" (click)="cerrarMenuMovil()" [attr.aria-label]="'comun.cerrarMenu' | translate" tabindex="-1"></button>
+  </aside>
 }

--- a/autodeploy/src/app/components/layout/header/header.html
+++ b/autodeploy/src/app/components/layout/header/header.html
@@ -1,6 +1,6 @@
 <header class="cabecera">
   <a class="cabecera__logo" routerLink="/">
-    <img class="cabecera__logo__imagen" src="logo.png" alt="AutoDeploy">
+    <img class="cabecera__logo__imagen" src="logo.png" alt="AutoDeploy" width="32" height="32">
     <span class="cabecera__logo__texto">Auto<span class="cabecera__logo__texto--acento">Deploy</span></span>
   </a>
 

--- a/autodeploy/src/app/components/layout/sidebar/sidebar.component.html
+++ b/autodeploy/src/app/components/layout/sidebar/sidebar.component.html
@@ -1,42 +1,45 @@
-<aside class="barra-lateral" [class.barra-lateral--abierta]="abierta()" [class.barra-lateral--colapsada]="colapsada()">
+<aside class="barra-lateral" [class.barra-lateral--abierta]="abierta()" [class.barra-lateral--colapsada]="colapsada()" [attr.aria-label]="'sidebar.ariaPrincipal' | translate">
   <a class="barra-lateral__logo" routerLink="/">
-    <img class="barra-lateral__logo__imagen" src="logo.png" alt="">
-    <span class="barra-lateral__logo__texto">Auto<span class="barra-lateral__logo__texto--acento">Deploy</span></span>
+    <img class="barra-lateral__logo__imagen" src="logo.png" alt="AutoDeploy">
+    <span class="barra-lateral__logo__texto" aria-hidden="true">Auto<span class="barra-lateral__logo__texto--acento">Deploy</span></span>
     <span class="barra-lateral__logo__version" aria-hidden="true">v2.41</span>
   </a>
 
-  <nav class="barra-lateral__navegacion">
-    <section class="barra-lateral__seccion" data-indice="01">
+  <nav class="barra-lateral__navegacion" [attr.aria-label]="'sidebar.ariaNavegacion' | translate">
+    <section class="barra-lateral__seccion" data-indice="01" aria-labelledby="barra-lateral-titulo-1">
       <header class="barra-lateral__seccion__cabecera">
         <span class="barra-lateral__seccion__numero" aria-hidden="true">01</span>
-        <span class="barra-lateral__seccion__titulo">{{ "sidebar.secciones.principal" | translate }}</span>
+        <span class="barra-lateral__seccion__titulo" id="barra-lateral-titulo-1">{{ "sidebar.secciones.principal" | translate }}</span>
       </header>
       <ul class="barra-lateral__lista">
         <li>
           <a class="barra-lateral__enlace" routerLink="/app/dashboard" routerLinkActive="barra-lateral__enlace--activo"
-            [routerLinkActiveOptions]="{ exact: true }">
-            <i class="fa-solid fa-table-columns barra-lateral__enlace__icono"></i>
+            [routerLinkActiveOptions]="{ exact: true }" #rla1="routerLinkActive" [attr.aria-current]="rla1.isActive ? 'page' : null">
+            <i class="fa-solid fa-table-columns barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.dashboard" | translate }}</span>
             <span class="barra-lateral__enlace__indicador" aria-hidden="true"></span>
           </a>
         </li>
         <li>
-          <a class="barra-lateral__enlace" routerLink="/app/onboarding" routerLinkActive="barra-lateral__enlace--activo">
-            <i class="fa-solid fa-plug barra-lateral__enlace__icono"></i>
+          <a class="barra-lateral__enlace" routerLink="/app/onboarding" routerLinkActive="barra-lateral__enlace--activo"
+            #rla2="routerLinkActive" [attr.aria-current]="rla2.isActive ? 'page' : null">
+            <i class="fa-solid fa-plug barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.conectarServidor" | translate }}</span>
             <span class="barra-lateral__enlace__indicador" aria-hidden="true"></span>
           </a>
         </li>
         <li>
-          <a class="barra-lateral__enlace" routerLink="/app/logs" routerLinkActive="barra-lateral__enlace--activo">
-            <i class="fa-solid fa-chart-line barra-lateral__enlace__icono"></i>
+          <a class="barra-lateral__enlace" routerLink="/app/logs" routerLinkActive="barra-lateral__enlace--activo"
+            #rla3="routerLinkActive" [attr.aria-current]="rla3.isActive ? 'page' : null">
+            <i class="fa-solid fa-chart-line barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.actividad" | translate }}</span>
             <span class="barra-lateral__enlace__indicador" aria-hidden="true"></span>
           </a>
         </li>
         <li>
-          <a class="barra-lateral__enlace" routerLink="/app/billing" routerLinkActive="barra-lateral__enlace--activo">
-            <i class="fa-solid fa-credit-card barra-lateral__enlace__icono"></i>
+          <a class="barra-lateral__enlace" routerLink="/app/billing" routerLinkActive="barra-lateral__enlace--activo"
+            #rla4="routerLinkActive" [attr.aria-current]="rla4.isActive ? 'page' : null">
+            <i class="fa-solid fa-credit-card barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.billing" | translate }}</span>
             <span class="barra-lateral__enlace__indicador" aria-hidden="true"></span>
           </a>
@@ -44,22 +47,24 @@
       </ul>
     </section>
 
-    <section class="barra-lateral__seccion" data-indice="02">
+    <section class="barra-lateral__seccion" data-indice="02" aria-labelledby="barra-lateral-titulo-2">
       <header class="barra-lateral__seccion__cabecera">
         <span class="barra-lateral__seccion__numero" aria-hidden="true">02</span>
-        <span class="barra-lateral__seccion__titulo">{{ "sidebar.secciones.servidor" | translate }}</span>
+        <span class="barra-lateral__seccion__titulo" id="barra-lateral-titulo-2">{{ "sidebar.secciones.servidor" | translate }}</span>
       </header>
       <ul class="barra-lateral__lista">
         <li>
-          <a class="barra-lateral__enlace" routerLink="/app/terminal" routerLinkActive="barra-lateral__enlace--activo">
-            <i class="fa-solid fa-terminal barra-lateral__enlace__icono"></i>
+          <a class="barra-lateral__enlace" routerLink="/app/terminal" routerLinkActive="barra-lateral__enlace--activo"
+            #rla5="routerLinkActive" [attr.aria-current]="rla5.isActive ? 'page' : null">
+            <i class="fa-solid fa-terminal barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.terminal" | translate }}</span>
             <span class="barra-lateral__enlace__indicador" aria-hidden="true"></span>
           </a>
         </li>
         <li>
-          <a class="barra-lateral__enlace" routerLink="/app/asistente-ia" routerLinkActive="barra-lateral__enlace--activo">
-            <i class="fa-solid fa-robot barra-lateral__enlace__icono"></i>
+          <a class="barra-lateral__enlace" routerLink="/app/asistente-ia" routerLinkActive="barra-lateral__enlace--activo"
+            #rla6="routerLinkActive" [attr.aria-current]="rla6.isActive ? 'page' : null">
+            <i class="fa-solid fa-robot barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.asistenteIa" | translate }}</span>
             @if (planService.planActual() !== 'pro' && planService.planActual() !== 'business') {
               <span class="barra-lateral__chip-pro">{{ "sidebar.chipPro" | translate }}</span>
@@ -69,29 +74,33 @@
         </li>
         <li>
           <a class="barra-lateral__enlace" routerLink="/app/nuevo-despliegue"
-            routerLinkActive="barra-lateral__enlace--activo">
-            <i class="fa-solid fa-cubes barra-lateral__enlace__icono"></i>
+            routerLinkActive="barra-lateral__enlace--activo"
+            #rla7="routerLinkActive" [attr.aria-current]="rla7.isActive ? 'page' : null">
+            <i class="fa-solid fa-cubes barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.aplicaciones" | translate }}</span>
             <span class="barra-lateral__enlace__indicador" aria-hidden="true"></span>
           </a>
         </li>
         <li>
-          <a class="barra-lateral__enlace" routerLink="/app/networking" routerLinkActive="barra-lateral__enlace--activo">
-            <i class="fa-solid fa-globe barra-lateral__enlace__icono"></i>
+          <a class="barra-lateral__enlace" routerLink="/app/networking" routerLinkActive="barra-lateral__enlace--activo"
+            #rla8="routerLinkActive" [attr.aria-current]="rla8.isActive ? 'page' : null">
+            <i class="fa-solid fa-globe barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.networking" | translate }}</span>
             <span class="barra-lateral__enlace__indicador" aria-hidden="true"></span>
           </a>
         </li>
         <li>
-          <a class="barra-lateral__enlace" routerLink="/app/firewall" routerLinkActive="barra-lateral__enlace--activo">
-            <i class="fa-solid fa-shield-halved barra-lateral__enlace__icono"></i>
+          <a class="barra-lateral__enlace" routerLink="/app/firewall" routerLinkActive="barra-lateral__enlace--activo"
+            #rla9="routerLinkActive" [attr.aria-current]="rla9.isActive ? 'page' : null">
+            <i class="fa-solid fa-shield-halved barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.firewall" | translate }}</span>
             <span class="barra-lateral__enlace__indicador" aria-hidden="true"></span>
           </a>
         </li>
         <li>
-          <a class="barra-lateral__enlace" routerLink="/app/backups" routerLinkActive="barra-lateral__enlace--activo">
-            <i class="fa-solid fa-hard-drive barra-lateral__enlace__icono"></i>
+          <a class="barra-lateral__enlace" routerLink="/app/backups" routerLinkActive="barra-lateral__enlace--activo"
+            #rla10="routerLinkActive" [attr.aria-current]="rla10.isActive ? 'page' : null">
+            <i class="fa-solid fa-hard-drive barra-lateral__enlace__icono" aria-hidden="true"></i>
             <span class="barra-lateral__enlace__texto">{{ "sidebar.nav.backups" | translate }}</span>
             <span class="barra-lateral__enlace__indicador" aria-hidden="true"></span>
           </a>
@@ -101,8 +110,8 @@
   </nav>
 
   <footer class="barra-lateral__inferior">
-    <button class="barra-lateral__colapsar" (click)="alternarColapso()">
-      <i class="barra-lateral__colapsar__icono" [class]="colapsada() ? 'fa-solid fa-angles-right' : 'fa-solid fa-angles-left'"></i>
+    <button class="barra-lateral__colapsar" (click)="alternarColapso()" [attr.aria-label]="'sidebar.ariaColapsar' | translate">
+      <i class="barra-lateral__colapsar__icono" [class]="colapsada() ? 'fa-solid fa-angles-right' : 'fa-solid fa-angles-left'" aria-hidden="true"></i>
       @if (!colapsada()) {
         <span class="barra-lateral__colapsar__texto">{{ "sidebar.colapsar" | translate }}</span>
       }
@@ -111,7 +120,7 @@
       <span class="barra-lateral__usuario__avatar" aria-hidden="true">
         <span class="barra-lateral__usuario__avatar__estado" aria-hidden="true"></span>
       </span>
-      <section class="barra-lateral__usuario__info">
+      <section class="barra-lateral__usuario__info" [attr.aria-label]="'sidebar.ariaInfoUsuario' | translate">
         <span class="barra-lateral__usuario__nombre">{{ usuarioService.nombre() || ("sidebar.fallbackCuenta" | translate) }}</span>
         <span class="barra-lateral__usuario__plan">{{ planService.planActual() }}</span>
       </section>

--- a/autodeploy/src/app/components/layout/sidebar/sidebar.component.html
+++ b/autodeploy/src/app/components/layout/sidebar/sidebar.component.html
@@ -1,6 +1,6 @@
 <aside class="barra-lateral" [class.barra-lateral--abierta]="abierta()" [class.barra-lateral--colapsada]="colapsada()" [attr.aria-label]="'sidebar.ariaPrincipal' | translate">
   <a class="barra-lateral__logo" routerLink="/">
-    <img class="barra-lateral__logo__imagen" src="logo.png" alt="AutoDeploy">
+    <img class="barra-lateral__logo__imagen" src="logo.png" alt="AutoDeploy" width="26" height="26">
     <span class="barra-lateral__logo__texto" aria-hidden="true">Auto<span class="barra-lateral__logo__texto--acento">Deploy</span></span>
     <span class="barra-lateral__logo__version" aria-hidden="true">v2.41</span>
   </a>

--- a/autodeploy/src/app/components/shared/galeria-capturas/galeria-capturas.html
+++ b/autodeploy/src/app/components/shared/galeria-capturas/galeria-capturas.html
@@ -1,0 +1,28 @@
+<section class="galeria-capturas" [attr.aria-label]="ariaTitulo">
+  <ul class="galeria-capturas__lista" role="list">
+    @for (captura of capturas; track captura.src) {
+      <li class="galeria-capturas__item">
+        <figure class="galeria-capturas__figura">
+          <picture>
+            @if (captura.srcMovil) {
+              <source media="(max-width: 48rem)" [srcset]="captura.srcMovil" type="image/webp">
+            }
+            <source [srcset]="captura.src" type="image/webp">
+            <img class="galeria-capturas__imagen"
+                 [src]="captura.fallback || captura.src"
+                 [alt]="captura.alt"
+                 [width]="captura.ancho"
+                 [height]="captura.alto"
+                 loading="lazy"
+                 decoding="async">
+          </picture>
+          <figcaption class="galeria-capturas__caption">{{ captura.titulo }}</figcaption>
+        </figure>
+      </li>
+    } @empty {
+      <li class="galeria-capturas__placeholder" aria-hidden="true">
+        Aún no hay capturas. Añade entradas al input <code>capturas</code> para mostrarlas.
+      </li>
+    }
+  </ul>
+</section>

--- a/autodeploy/src/app/components/shared/galeria-capturas/galeria-capturas.scss
+++ b/autodeploy/src/app/components/shared/galeria-capturas/galeria-capturas.scss
@@ -1,0 +1,3 @@
+// Los estilos del componente reutilizable viven en
+// src/styles/05-components/_galeria-capturas.scss para mantener el patrón
+// global del proyecto (ITCSS + estilos compartidos).

--- a/autodeploy/src/app/components/shared/galeria-capturas/galeria-capturas.ts
+++ b/autodeploy/src/app/components/shared/galeria-capturas/galeria-capturas.ts
@@ -1,0 +1,44 @@
+import { Component, Input } from "@angular/core";
+
+/**
+ * Una captura de pantalla del producto destinada a la galería accesible.
+ *
+ * Cada entrada genera un <figure> con <picture> y <figcaption>. El campo
+ * `alt` debe describir la información que aporta la imagen (no su
+ * apariencia), porque es lo que leerán los usuarios de lectores de
+ * pantalla. El `titulo` corto va en el caption visible para el resto de
+ * usuarios.
+ */
+export interface Captura {
+  /** Ruta base del WebP de desktop (1200px). */
+  src: string;
+  /** Ruta de la variante mobile (800px). Opcional. */
+  srcMovil?: string;
+  /** Fallback en JPG/PNG por si el navegador no soporta WebP. Opcional. */
+  fallback?: string;
+  /** Descripción significativa de lo que muestra la imagen. */
+  alt: string;
+  /** Texto corto del caption visible bajo la imagen. */
+  titulo: string;
+  /** Ancho intrínseco del archivo desktop (para evitar layout shift). */
+  ancho: number;
+  /** Alto intrínseco del archivo desktop. */
+  alto: number;
+}
+
+@Component({
+  selector: "app-galeria-capturas",
+  templateUrl: "./galeria-capturas.html",
+  styleUrl: "./galeria-capturas.scss",
+})
+export class GaleriaCapturas {
+  /** Conjunto de capturas a renderizar. Pasarlo desde la página padre. */
+  @Input() capturas: Captura[] = [];
+
+  /**
+   * Texto accesible que describe el conjunto. Va al `aria-labelledby` del
+   * <section> contenedor. Si la página padre ya provee un encabezado
+   * adyacente, puede ignorar este input.
+   */
+  @Input() ariaTitulo: string = "Galería de capturas de AutoDeploy";
+}

--- a/autodeploy/src/app/pages/login/login.html
+++ b/autodeploy/src/app/pages/login/login.html
@@ -3,7 +3,7 @@
   <aside class="pagina-login__panel-marca">
     <header class="pagina-login__panel-marca__cabecera">
       <a class="pagina-login__logo" routerLink="/">
-        <img class="pagina-login__logo__imagen" src="logo.png" alt="AutoDeploy">
+        <img class="pagina-login__logo__imagen" src="logo.png" alt="AutoDeploy" width="32" height="32">
         <span class="pagina-login__logo__texto">Auto<span class="pagina-login__logo__texto--acento">Deploy</span></span>
       </a>
       <span class="pagina-login__sello">

--- a/autodeploy/src/app/pages/pago/pago.html
+++ b/autodeploy/src/app/pages/pago/pago.html
@@ -11,7 +11,7 @@
         {{ "pago.volver" | translate }}
       </a>
       <a class="pagina-pago__logo" routerLink="/">
-        <img class="pagina-pago__logo__imagen" src="logo.png" alt="">
+        <img class="pagina-pago__logo__imagen" src="logo.png" alt="AutoDeploy" width="32" height="32">
         <span class="pagina-pago__logo__texto">Auto<span class="pagina-pago__logo__texto--acento">Deploy</span></span>
       </a>
     </header>

--- a/autodeploy/src/app/pages/register/register.html
+++ b/autodeploy/src/app/pages/register/register.html
@@ -124,7 +124,7 @@
         {{ 'register.sello' | translate }}
       </span>
       <a class="pagina-registro__logo" routerLink="/">
-        <img class="pagina-registro__logo__imagen" src="logo.png" alt="AutoDeploy">
+        <img class="pagina-registro__logo__imagen" src="logo.png" alt="AutoDeploy" width="32" height="32">
         <span class="pagina-registro__logo__texto">Auto<span class="pagina-registro__logo__texto--acento">Deploy</span></span>
       </a>
     </header>

--- a/autodeploy/src/app/pages/style-guide/style-guide.html
+++ b/autodeploy/src/app/pages/style-guide/style-guide.html
@@ -17,6 +17,7 @@
       <li><a href="#formularios">Formularios</a></li>
       <li><a href="#tarjetas">Tarjetas</a></li>
       <li><a href="#feedback">Feedback</a></li>
+      <li><a href="#multimedia">Multimedia</a></li>
       <li><a href="#animaciones">Animaciones</a></li>
     </ol>
   </nav>
@@ -289,9 +290,23 @@
     </section>
   </section>
 
-  <section class="pagina-style-guide__seccion" id="animaciones" aria-labelledby="titulo-animaciones">
+  <section class="pagina-style-guide__seccion" id="multimedia" aria-labelledby="titulo-multimedia">
     <header class="pagina-style-guide__seccion__cabecera">
       <p class="pagina-style-guide__seccion__numero" aria-hidden="true">08</p>
+      <h2 class="pagina-style-guide__seccion__titulo" id="titulo-multimedia">Multimedia accesible</h2>
+      <p class="pagina-style-guide__seccion__descripcion">
+        Componente <code>&lt;app-galeria-capturas&gt;</code> con <code>&lt;figure&gt;</code> + <code>&lt;figcaption&gt;</code> +
+        <code>&lt;picture&gt;</code>/<code>srcset</code> + <code>loading="lazy"</code>. Recibe las capturas como
+        Input; abajo aparece en estado vacío porque las capturas reales se incorporarán al final del refactor.
+      </p>
+    </header>
+
+    <app-galeria-capturas [capturas]="capturasDemo" ariaTitulo="Capturas del producto (demo)"></app-galeria-capturas>
+  </section>
+
+  <section class="pagina-style-guide__seccion" id="animaciones" aria-labelledby="titulo-animaciones">
+    <header class="pagina-style-guide__seccion__cabecera">
+      <p class="pagina-style-guide__seccion__numero" aria-hidden="true">09</p>
       <h2 class="pagina-style-guide__seccion__titulo" id="titulo-animaciones">Animaciones</h2>
       <p class="pagina-style-guide__seccion__descripcion">
         Todas usan sólo <code>transform</code> y <code>opacity</code> con timing function

--- a/autodeploy/src/app/pages/style-guide/style-guide.html
+++ b/autodeploy/src/app/pages/style-guide/style-guide.html
@@ -1,0 +1,322 @@
+<article class="pagina-style-guide">
+  <header class="pagina-style-guide__cabecera">
+    <p class="pagina-style-guide__superior">Documentación visual</p>
+    <h1 class="pagina-style-guide__titulo">Style Guide de AutoDeploy</h1>
+    <p class="pagina-style-guide__intro">
+      Todos los componentes del sistema con sus variantes y estados. Sirve como referencia para el equipo y como
+      testing rápido del sistema de diseño.
+    </p>
+  </header>
+
+  <nav class="pagina-style-guide__indice" aria-label="Índice de secciones del style guide">
+    <ol class="pagina-style-guide__indice-lista">
+      <li><a href="#tipografia">Tipografía</a></li>
+      <li><a href="#colores">Colores</a></li>
+      <li><a href="#espaciado">Espaciado</a></li>
+      <li><a href="#botones">Botones</a></li>
+      <li><a href="#formularios">Formularios</a></li>
+      <li><a href="#tarjetas">Tarjetas</a></li>
+      <li><a href="#feedback">Feedback</a></li>
+      <li><a href="#animaciones">Animaciones</a></li>
+    </ol>
+  </nav>
+
+  <section class="pagina-style-guide__seccion" id="tipografia" aria-labelledby="titulo-tipografia">
+    <header class="pagina-style-guide__seccion__cabecera">
+      <p class="pagina-style-guide__seccion__numero" aria-hidden="true">01</p>
+      <h2 class="pagina-style-guide__seccion__titulo" id="titulo-tipografia">Tipografía</h2>
+      <p class="pagina-style-guide__seccion__descripcion">
+        Familia <strong>Outfit</strong> (cuerpo) y <strong>JetBrains Mono</strong> (snippets). Escala definida por
+        las custom properties <code>--font-size-*</code> y peso por <code>--font-weight-*</code>.
+      </p>
+    </header>
+
+    <section class="pagina-style-guide__bloque" aria-labelledby="tipografia-escala">
+      <h3 class="pagina-style-guide__bloque__titulo" id="tipografia-escala">Escala completa</h3>
+      <ul class="pagina-style-guide__lista-tipografia" role="list">
+        <li><span style="font-size: var(--font-size-5xl); font-weight: var(--font-weight-bold);">5xl · Hero principal</span><code>3.5rem</code></li>
+        <li><span style="font-size: var(--font-size-4xl); font-weight: var(--font-weight-bold);">4xl · Hero secundario</span><code>2.5rem</code></li>
+        <li><span style="font-size: var(--font-size-3xl); font-weight: var(--font-weight-bold);">3xl · Título de página</span><code>2rem</code></li>
+        <li><span style="font-size: var(--font-size-2xl); font-weight: var(--font-weight-semibold);">2xl · H2 destacado</span><code>1.75rem</code></li>
+        <li><span style="font-size: var(--font-size-xl); font-weight: var(--font-weight-semibold);">xl · Subtítulo</span><code>1.5rem</code></li>
+        <li><span style="font-size: var(--font-size-lg); font-weight: var(--font-weight-semibold);">lg · Lead</span><code>1.25rem</code></li>
+        <li><span style="font-size: var(--font-size-base);">base · Cuerpo</span><code>1rem</code></li>
+        <li><span style="font-size: var(--font-size-md);">md · Botones, inputs</span><code>0.875rem</code></li>
+        <li><span style="font-size: var(--font-size-sm);">sm · Metadatos</span><code>0.6875rem</code></li>
+        <li><span style="font-size: var(--font-size-xs);">xs · Tags y badges</span><code>0.625rem</code></li>
+      </ul>
+    </section>
+
+    <section class="pagina-style-guide__bloque" aria-labelledby="tipografia-pesos">
+      <h3 class="pagina-style-guide__bloque__titulo" id="tipografia-pesos">Pesos disponibles</h3>
+      <ul class="pagina-style-guide__lista-pesos" role="list">
+        <li style="font-weight: var(--font-weight-normal);">400 · Normal</li>
+        <li style="font-weight: var(--font-weight-medium);">500 · Medium</li>
+        <li style="font-weight: var(--font-weight-semibold);">600 · Semibold</li>
+        <li style="font-weight: var(--font-weight-bold);">700 · Bold</li>
+        <li style="font-weight: var(--font-weight-extrabold);">800 · Extrabold</li>
+        <li style="font-weight: var(--font-weight-black);">900 · Black</li>
+      </ul>
+    </section>
+  </section>
+
+  <section class="pagina-style-guide__seccion" id="colores" aria-labelledby="titulo-colores">
+    <header class="pagina-style-guide__seccion__cabecera">
+      <p class="pagina-style-guide__seccion__numero" aria-hidden="true">02</p>
+      <h2 class="pagina-style-guide__seccion__titulo" id="titulo-colores">Colores</h2>
+      <p class="pagina-style-guide__seccion__descripcion">
+        Tokens HSL definidos en <code>02-generic/_design-tokens.scss</code>. Los semánticos no cambian con el tema.
+      </p>
+    </header>
+
+    <section class="pagina-style-guide__bloque" aria-labelledby="colores-fondos">
+      <h3 class="pagina-style-guide__bloque__titulo" id="colores-fondos">Fondos</h3>
+      <ul class="pagina-style-guide__lista-color" role="list">
+        <li><span class="pagina-style-guide__muestra" style="background-color: var(--fondo-normal);"></span><code>--fondo-normal</code></li>
+        <li><span class="pagina-style-guide__muestra" style="background-color: var(--fondo-oscuro);"></span><code>--fondo-oscuro</code></li>
+        <li><span class="pagina-style-guide__muestra" style="background-color: var(--fondo-tarjeta);"></span><code>--fondo-tarjeta</code></li>
+        <li><span class="pagina-style-guide__muestra" style="background-color: var(--fondo-negro);"></span><code>--fondo-negro</code></li>
+        <li><span class="pagina-style-guide__muestra" style="background-color: var(--fondo-cta-claro);"></span><code>--fondo-cta-claro</code></li>
+      </ul>
+    </section>
+
+    <section class="pagina-style-guide__bloque" aria-labelledby="colores-acento">
+      <h3 class="pagina-style-guide__bloque__titulo" id="colores-acento">Acento</h3>
+      <ul class="pagina-style-guide__lista-color" role="list">
+        <li><span class="pagina-style-guide__muestra" style="background-color: var(--amarillo-normal);"></span><code>--amarillo-normal</code></li>
+        <li><span class="pagina-style-guide__muestra" style="background-color: var(--amarillo-normal-hover);"></span><code>--amarillo-normal-hover</code></li>
+      </ul>
+    </section>
+
+    <section class="pagina-style-guide__bloque" aria-labelledby="colores-textos">
+      <h3 class="pagina-style-guide__bloque__titulo" id="colores-textos">Textos</h3>
+      <ul class="pagina-style-guide__lista-color" role="list">
+        <li><span class="pagina-style-guide__muestra" style="background-color: var(--texto-claro);"></span><code>--texto-claro</code></li>
+        <li><span class="pagina-style-guide__muestra" style="background-color: var(--texto-medio);"></span><code>--texto-medio</code></li>
+        <li><span class="pagina-style-guide__muestra" style="background-color: var(--texto-apagado);"></span><code>--texto-apagado</code></li>
+      </ul>
+    </section>
+
+    <section class="pagina-style-guide__bloque" aria-labelledby="colores-estado">
+      <h3 class="pagina-style-guide__bloque__titulo" id="colores-estado">Estado</h3>
+      <ul class="pagina-style-guide__lista-color" role="list">
+        <li><span class="pagina-style-guide__muestra" style="background-color: var(--verde-normal);"></span><code>--verde-normal</code></li>
+        <li><span class="pagina-style-guide__muestra" style="background-color: var(--rojo-normal);"></span><code>--rojo-normal</code></li>
+        <li><span class="pagina-style-guide__muestra" style="background-color: var(--rojo-critico);"></span><code>--rojo-critico</code></li>
+        <li><span class="pagina-style-guide__muestra" style="background-color: var(--naranja-normal);"></span><code>--naranja-normal</code></li>
+        <li><span class="pagina-style-guide__muestra" style="background-color: var(--azul-normal);"></span><code>--azul-normal</code></li>
+        <li><span class="pagina-style-guide__muestra" style="background-color: var(--cyan-normal);"></span><code>--cyan-normal</code></li>
+        <li><span class="pagina-style-guide__muestra" style="background-color: var(--teal-normal);"></span><code>--teal-normal</code></li>
+      </ul>
+    </section>
+  </section>
+
+  <section class="pagina-style-guide__seccion" id="espaciado" aria-labelledby="titulo-espaciado">
+    <header class="pagina-style-guide__seccion__cabecera">
+      <p class="pagina-style-guide__seccion__numero" aria-hidden="true">03</p>
+      <h2 class="pagina-style-guide__seccion__titulo" id="titulo-espaciado">Espaciado</h2>
+      <p class="pagina-style-guide__seccion__descripcion">
+        15 niveles definidos en múltiplos de 4 y 8 px. Sirven para gap, padding, margin y posición.
+      </p>
+    </header>
+
+    <ul class="pagina-style-guide__lista-espaciado" role="list">
+      <li><span class="pagina-style-guide__muestra-espaciado" style="width: var(--spacing-size-xxs);"></span><code>--spacing-size-xxs (0.25rem)</code></li>
+      <li><span class="pagina-style-guide__muestra-espaciado" style="width: var(--spacing-size-xs);"></span><code>--spacing-size-xs (0.375rem)</code></li>
+      <li><span class="pagina-style-guide__muestra-espaciado" style="width: var(--spacing-size-s);"></span><code>--spacing-size-s (0.5rem)</code></li>
+      <li><span class="pagina-style-guide__muestra-espaciado" style="width: var(--spacing-size-m);"></span><code>--spacing-size-m (0.75rem)</code></li>
+      <li><span class="pagina-style-guide__muestra-espaciado" style="width: var(--spacing-size-l);"></span><code>--spacing-size-l (1rem)</code></li>
+      <li><span class="pagina-style-guide__muestra-espaciado" style="width: var(--spacing-size-xl);"></span><code>--spacing-size-xl (1.25rem)</code></li>
+      <li><span class="pagina-style-guide__muestra-espaciado" style="width: var(--spacing-size-2xl);"></span><code>--spacing-size-2xl (1.5rem)</code></li>
+      <li><span class="pagina-style-guide__muestra-espaciado" style="width: var(--spacing-size-3xl);"></span><code>--spacing-size-3xl (2rem)</code></li>
+      <li><span class="pagina-style-guide__muestra-espaciado" style="width: var(--spacing-size-4xl);"></span><code>--spacing-size-4xl (2.5rem)</code></li>
+      <li><span class="pagina-style-guide__muestra-espaciado" style="width: var(--spacing-size-5xl);"></span><code>--spacing-size-5xl (3rem)</code></li>
+      <li><span class="pagina-style-guide__muestra-espaciado" style="width: var(--spacing-size-6xl);"></span><code>--spacing-size-6xl (4rem)</code></li>
+    </ul>
+  </section>
+
+  <section class="pagina-style-guide__seccion" id="botones" aria-labelledby="titulo-botones">
+    <header class="pagina-style-guide__seccion__cabecera">
+      <p class="pagina-style-guide__seccion__numero" aria-hidden="true">04</p>
+      <h2 class="pagina-style-guide__seccion__titulo" id="titulo-botones">Botones</h2>
+      <p class="pagina-style-guide__seccion__descripcion">
+        4 variantes con todos los estados (<code>:hover</code>, <code>:active</code>, <code>:focus-visible</code>,
+        <code>:disabled</code>). Tabula sobre la página para ver el outline del foco.
+      </p>
+    </header>
+
+    <section class="pagina-style-guide__bloque" aria-labelledby="botones-variantes">
+      <h3 class="pagina-style-guide__bloque__titulo" id="botones-variantes">Variantes</h3>
+      <section class="pagina-style-guide__galeria">
+        <button type="button" class="boton boton--primario">Acción principal</button>
+        <button type="button" class="boton boton--secundario">Acción secundaria</button>
+        <button type="button" class="boton boton--ghost">Acción terciaria</button>
+        <button type="button" class="boton boton--peligro">Acción destructiva</button>
+      </section>
+    </section>
+
+    <section class="pagina-style-guide__bloque" aria-labelledby="botones-disabled">
+      <h3 class="pagina-style-guide__bloque__titulo" id="botones-disabled">Estado disabled</h3>
+      <section class="pagina-style-guide__galeria">
+        <button type="button" class="boton boton--primario" disabled>Primario disabled</button>
+        <button type="button" class="boton boton--secundario" disabled>Secundario disabled</button>
+        <button type="button" class="boton boton--ghost" disabled>Ghost disabled</button>
+        <button type="button" class="boton boton--peligro" disabled>Peligro disabled</button>
+      </section>
+    </section>
+  </section>
+
+  <section class="pagina-style-guide__seccion" id="formularios" aria-labelledby="titulo-formularios">
+    <header class="pagina-style-guide__seccion__cabecera">
+      <p class="pagina-style-guide__seccion__numero" aria-hidden="true">05</p>
+      <h2 class="pagina-style-guide__seccion__titulo" id="titulo-formularios">Formularios</h2>
+      <p class="pagina-style-guide__seccion__descripcion">
+        Inputs con label asociado, <code>:focus-visible</code> y <code>:invalid:not(:focus)</code> para feedback
+        inmediato. Toggle e interruptor con sus estados.
+      </p>
+    </header>
+
+    <form class="pagina-style-guide__formulario" (ngSubmit)="$event.preventDefault()">
+      <fieldset class="pagina-style-guide__fieldset">
+        <legend class="pagina-style-guide__legend">Datos de ejemplo</legend>
+
+        <article class="campo">
+          <label class="campo__etiqueta" for="sg-email">Correo electrónico</label>
+          <input class="campo__input" id="sg-email" name="email" type="email" required placeholder="tu@correo.com">
+          <p class="campo__pista">Te enviaremos un código de verificación.</p>
+        </article>
+
+        <article class="campo">
+          <label class="campo__etiqueta" for="sg-textarea">Notas</label>
+          <textarea class="campo__textarea" id="sg-textarea" name="notas" placeholder="Escribe aquí..."></textarea>
+        </article>
+
+        <article class="campo">
+          <label class="campo__etiqueta" for="sg-select">Plan</label>
+          <select class="campo__select" id="sg-select" name="plan">
+            <option value="free">Gratis</option>
+            <option value="pro">Pro</option>
+            <option value="business">Business</option>
+          </select>
+        </article>
+
+        <article class="campo">
+          <label class="campo__etiqueta" for="sg-disabled">Campo deshabilitado</label>
+          <input class="campo__input" id="sg-disabled" name="disabled" type="text" disabled value="No editable">
+        </article>
+      </fieldset>
+
+      <section class="pagina-style-guide__bloque" aria-labelledby="form-toggle">
+        <h3 class="pagina-style-guide__bloque__titulo" id="form-toggle">Toggle (segmented control)</h3>
+        <section class="toggle" role="group" aria-label="Frecuencia de backups">
+          <button type="button" class="toggle__opcion toggle__opcion--activa">Diario</button>
+          <button type="button" class="toggle__opcion">Semanal</button>
+          <button type="button" class="toggle__opcion">Mensual</button>
+        </section>
+      </section>
+
+      <section class="pagina-style-guide__bloque" aria-labelledby="form-interruptor">
+        <h3 class="pagina-style-guide__bloque__titulo" id="form-interruptor">Interruptor (switch)</h3>
+        <section class="pagina-style-guide__galeria">
+          <button type="button" class="interruptor" aria-pressed="false" aria-label="Interruptor desactivado">
+            <span class="interruptor__circulo"></span>
+          </button>
+          <button type="button" class="interruptor interruptor--activo" aria-pressed="true" aria-label="Interruptor activado">
+            <span class="interruptor__circulo interruptor__circulo--activo"></span>
+          </button>
+        </section>
+      </section>
+    </form>
+  </section>
+
+  <section class="pagina-style-guide__seccion" id="tarjetas" aria-labelledby="titulo-tarjetas">
+    <header class="pagina-style-guide__seccion__cabecera">
+      <p class="pagina-style-guide__seccion__numero" aria-hidden="true">06</p>
+      <h2 class="pagina-style-guide__seccion__titulo" id="titulo-tarjetas">Tarjetas</h2>
+      <p class="pagina-style-guide__seccion__descripcion">
+        Las tarjetas usan <code>container-type: inline-size</code>: arrastra el borde del navegador para verlas
+        adaptarse al ancho del contenedor sin que el viewport cambie.
+      </p>
+    </header>
+
+    <section class="pagina-style-guide__galeria-tarjetas">
+      @for (servidor of servidoresDemo; track servidor.nombre) {
+        <article class="tarjeta-servidor">
+          <header class="tarjeta-servidor__cabecera">
+            <span class="tarjeta-servidor__indicador" [class.tarjeta-servidor__indicador--verde]="servidor.estado === 'verde'" [class.tarjeta-servidor__indicador--naranja]="servidor.estado === 'naranja'" [class.tarjeta-servidor__indicador--rojo]="servidor.estado === 'rojo'" aria-hidden="true"></span>
+            <span class="tarjeta-servidor__nombre">{{ servidor.nombre }}</span>
+            <span class="tarjeta-servidor__ip">{{ servidor.ip }}</span>
+          </header>
+          <section class="tarjeta-servidor__metricas" aria-label="Métricas del servidor">
+            <section class="tarjeta-servidor__metrica">
+              <span class="tarjeta-servidor__metrica__etiqueta">CPU</span>
+              <span class="tarjeta-servidor__metrica__valor">{{ servidor.cpu }}%</span>
+            </section>
+            <section class="tarjeta-servidor__metrica">
+              <span class="tarjeta-servidor__metrica__etiqueta">RAM</span>
+              <span class="tarjeta-servidor__metrica__valor">{{ servidor.ram }}%</span>
+            </section>
+            <section class="tarjeta-servidor__metrica">
+              <span class="tarjeta-servidor__metrica__etiqueta">Disco</span>
+              <span class="tarjeta-servidor__metrica__valor">{{ servidor.disco }}%</span>
+            </section>
+          </section>
+          <footer class="tarjeta-servidor__pie">
+            <a class="tarjeta-servidor__enlace" href="javascript:void(0)">Ver detalles</a>
+          </footer>
+        </article>
+      }
+    </section>
+  </section>
+
+  <section class="pagina-style-guide__seccion" id="feedback" aria-labelledby="titulo-feedback">
+    <header class="pagina-style-guide__seccion__cabecera">
+      <p class="pagina-style-guide__seccion__numero" aria-hidden="true">07</p>
+      <h2 class="pagina-style-guide__seccion__titulo" id="titulo-feedback">Feedback</h2>
+      <p class="pagina-style-guide__seccion__descripcion">
+        Spinner de carga (3 variantes de tamaño y color), animaciones de aparición rápida y entrada con stagger.
+      </p>
+    </header>
+
+    <section class="pagina-style-guide__bloque" aria-labelledby="feedback-spinner">
+      <h3 class="pagina-style-guide__bloque__titulo" id="feedback-spinner">Spinner</h3>
+      <section class="pagina-style-guide__galeria">
+        <span class="spinner" aria-label="Cargando"></span>
+        <span class="spinner spinner--grande" aria-label="Cargando (grande)"></span>
+        <span class="spinner spinner--cyan" aria-label="Cargando (cyan)"></span>
+        <span class="spinner spinner--verde" aria-label="Cargando (verde)"></span>
+      </section>
+    </section>
+  </section>
+
+  <section class="pagina-style-guide__seccion" id="animaciones" aria-labelledby="titulo-animaciones">
+    <header class="pagina-style-guide__seccion__cabecera">
+      <p class="pagina-style-guide__seccion__numero" aria-hidden="true">08</p>
+      <h2 class="pagina-style-guide__seccion__titulo" id="titulo-animaciones">Animaciones</h2>
+      <p class="pagina-style-guide__seccion__descripcion">
+        Todas usan sólo <code>transform</code> y <code>opacity</code> con timing function
+        <code>cubic-bezier(0.16, 1, 0.3, 1)</code>. Se desactivan globalmente si el usuario tiene activado
+        <code>prefers-reduced-motion: reduce</code>.
+      </p>
+    </header>
+
+    <section class="pagina-style-guide__bloque" aria-labelledby="anim-aparecer">
+      <h3 class="pagina-style-guide__bloque__titulo" id="anim-aparecer">.aparecer</h3>
+      <article class="pagina-style-guide__demo-animacion aparecer">
+        Fade desde abajo (0.32s)
+      </article>
+    </section>
+
+    <section class="pagina-style-guide__bloque" aria-labelledby="anim-stagger">
+      <h3 class="pagina-style-guide__bloque__titulo" id="anim-stagger">.animar-hijos &gt; *</h3>
+      <ul class="pagina-style-guide__demo-stagger animar-hijos" role="list">
+        <li>Hijo 1</li>
+        <li>Hijo 2</li>
+        <li>Hijo 3</li>
+        <li>Hijo 4</li>
+        <li>Hijo 5</li>
+        <li>Hijo 6</li>
+      </ul>
+    </section>
+  </section>
+</article>

--- a/autodeploy/src/app/pages/style-guide/style-guide.scss
+++ b/autodeploy/src/app/pages/style-guide/style-guide.scss
@@ -1,0 +1,2 @@
+// Los estilos viven en src/styles/05-components/_pagina-style-guide.scss
+// para mantener el patrón global del proyecto.

--- a/autodeploy/src/app/pages/style-guide/style-guide.ts
+++ b/autodeploy/src/app/pages/style-guide/style-guide.ts
@@ -1,0 +1,17 @@
+import { Component } from "@angular/core";
+
+@Component({
+  selector: "app-style-guide",
+  templateUrl: "./style-guide.html",
+  styleUrl: "./style-guide.scss",
+})
+export class StyleGuide {
+  // Datos de demostración para las tarjetas de servidor mostradas en la
+  // sección de componentes. No conecta con el backend porque esta página
+  // sirve sólo como documentación visual.
+  servidoresDemo = [
+    { nombre: "vps-prod-01", ip: "203.0.113.42", estado: "verde", cpu: 24, ram: 58, disco: 42 },
+    { nombre: "vps-dev-02", ip: "203.0.113.55", estado: "naranja", cpu: 87, ram: 73, disco: 65 },
+    { nombre: "vps-test-03", ip: "203.0.113.71", estado: "rojo", cpu: 0, ram: 0, disco: 0 },
+  ];
+}

--- a/autodeploy/src/app/pages/style-guide/style-guide.ts
+++ b/autodeploy/src/app/pages/style-guide/style-guide.ts
@@ -1,9 +1,11 @@
 import { Component } from "@angular/core";
+import { Captura, GaleriaCapturas } from "../../components/shared/galeria-capturas/galeria-capturas";
 
 @Component({
   selector: "app-style-guide",
   templateUrl: "./style-guide.html",
   styleUrl: "./style-guide.scss",
+  imports: [GaleriaCapturas],
 })
 export class StyleGuide {
   // Datos de demostración para las tarjetas de servidor mostradas en la
@@ -14,4 +16,10 @@ export class StyleGuide {
     { nombre: "vps-dev-02", ip: "203.0.113.55", estado: "naranja", cpu: 87, ram: 73, disco: 65 },
     { nombre: "vps-test-03", ip: "203.0.113.71", estado: "rojo", cpu: 0, ram: 0, disco: 0 },
   ];
+
+  // Capturas reales pendientes. Cuando se incorporen a /img/capturas/
+  // bastará con descomentar las entradas o cambiar las rutas. Mientras,
+  // la galería renderiza su estado vacío para que se aprecie el
+  // componente con su mensaje de placeholder.
+  capturasDemo: Captura[] = [];
 }

--- a/autodeploy/src/app/services/theme.service.ts
+++ b/autodeploy/src/app/services/theme.service.ts
@@ -1,20 +1,94 @@
-import { Injectable, signal, effect } from "@angular/core";
+import { DOCUMENT } from "@angular/common";
+import { Injectable, effect, inject, signal } from "@angular/core";
 
 type Tema = "oscuro" | "claro";
 
+const CLAVE_ALMACEN = "tema";
+const CLASE_TEMA_CLARO = "tema-claro";
+
 @Injectable({ providedIn: "root" })
 export class ThemeService {
-  temaActual = signal<Tema>((localStorage.getItem("tema") as Tema) ?? "oscuro");
+  private documento = inject(DOCUMENT);
+
+  // Indica si el usuario eligió tema manualmente (true) o si se está
+  // siguiendo automáticamente la preferencia del sistema (false). Sólo
+  // así puede reaccionar a cambios futuros del SO sin pisar la elección
+  // explícita del usuario.
+  private eleccionManual = signal<boolean>(this.haGuardado());
+
+  temaActual = signal<Tema>(this.temaInicial());
 
   constructor() {
+    // Aplica la clase y persiste sólo si el cambio viene de una elección
+    // manual; al inicializar con la preferencia del sistema no se guarda
+    // para que el usuario pueda volver al modo automático borrando el
+    // localStorage.
     effect(() => {
       const tema = this.temaActual();
-      localStorage.setItem("tema", tema);
-      document.documentElement.classList.toggle("tema-claro", tema === "claro");
+      this.documento.documentElement.classList.toggle(CLASE_TEMA_CLARO, tema === "claro");
+
+      if (this.eleccionManual()) {
+        try {
+          this.almacen()?.setItem(CLAVE_ALMACEN, tema);
+        } catch {
+          // Si localStorage está bloqueado (modo incógnito, política de
+          // privacidad) seguimos funcionando: el tema se mantiene sólo
+          // mientras dura la sesión.
+        }
+      }
     });
+
+    this.escucharSistema();
   }
 
   alternarTema(): void {
+    this.eleccionManual.set(true);
     this.temaActual.update(t => (t === "oscuro" ? "claro" : "oscuro"));
+  }
+
+  private temaInicial(): Tema {
+    const guardado = this.almacen()?.getItem(CLAVE_ALMACEN);
+    if (guardado === "oscuro" || guardado === "claro") {
+      return guardado;
+    }
+    return this.preferenciaDelSistema();
+  }
+
+  private haGuardado(): boolean {
+    const guardado = this.almacen()?.getItem(CLAVE_ALMACEN);
+    return guardado === "oscuro" || guardado === "claro";
+  }
+
+  private preferenciaDelSistema(): Tema {
+    const ventana = this.documento.defaultView;
+    if (!ventana?.matchMedia) {
+      return "oscuro";
+    }
+    return ventana.matchMedia("(prefers-color-scheme: light)").matches ? "claro" : "oscuro";
+  }
+
+  // Suscribe el servicio al cambio de la preferencia del sistema. Si el
+  // usuario nunca ha pulsado el botón de cambio de tema, la app sigue
+  // automáticamente lo que dicte el sistema operativo.
+  private escucharSistema(): void {
+    const ventana = this.documento.defaultView;
+    if (!ventana?.matchMedia) {
+      return;
+    }
+    const consulta = ventana.matchMedia("(prefers-color-scheme: light)");
+    consulta.addEventListener("change", evento => {
+      if (this.eleccionManual()) {
+        return;
+      }
+      this.temaActual.set(evento.matches ? "claro" : "oscuro");
+    });
+  }
+
+  private almacen(): Storage | null {
+    try {
+      return this.documento.defaultView?.localStorage ?? null;
+    } catch {
+      return null;
+    }
   }
 }

--- a/autodeploy/src/styles.scss
+++ b/autodeploy/src/styles.scss
@@ -63,6 +63,7 @@
 @use "styles/05-components/pagina-contacto";
 @use "styles/05-components/pagina-comunidad";
 @use "styles/05-components/pagina-style-guide";
+@use "styles/05-components/galeria-capturas";
 
 // 06 · Utilities — helpers con prefijo .u-. Última capa, gana por orden.
 @use "styles/06-utilities/visibilidad";

--- a/autodeploy/src/styles.scss
+++ b/autodeploy/src/styles.scss
@@ -62,6 +62,7 @@
 @use "styles/05-components/pagina-estado";
 @use "styles/05-components/pagina-contacto";
 @use "styles/05-components/pagina-comunidad";
+@use "styles/05-components/pagina-style-guide";
 
 // 06 · Utilities — helpers con prefijo .u-. Última capa, gana por orden.
 @use "styles/06-utilities/visibilidad";

--- a/autodeploy/src/styles.scss
+++ b/autodeploy/src/styles.scss
@@ -67,6 +67,10 @@
 @use "styles/06-utilities/visibilidad";
 @use "styles/06-utilities/texto";
 @use "styles/06-utilities/espaciados";
+@use "styles/06-utilities/flex";
+@use "styles/06-utilities/display";
+@use "styles/06-utilities/z-index";
+@use "styles/06-utilities/saltar-contenido";
 
 // Vendor CSS (xterm) — al final para que el reset no lo machaque.
 @import "@xterm/xterm/css/xterm.css";

--- a/autodeploy/src/styles.scss
+++ b/autodeploy/src/styles.scss
@@ -7,8 +7,9 @@
 @use "styles/00-settings/css-variables";
 @use "styles/00-settings/variables";
 
-// 01 · Tools — mixins, helpers y animaciones reutilizables.
+// 01 · Tools — mixins, funciones y animaciones reutilizables.
 @use "styles/01-tools/mixins";
+@use "styles/01-tools/funciones";
 @use "styles/01-tools/animaciones";
 
 // 02 · Generic — reset + design tokens (Custom Properties CSS).

--- a/autodeploy/src/styles/01-tools/_animaciones.scss
+++ b/autodeploy/src/styles/01-tools/_animaciones.scss
@@ -2,6 +2,8 @@
 // Las animaciones específicas de un componente viven con su componente
 // (p.ej. .seccion-bienvenida__terminal__linea está en _seccion-bienvenida.scss).
 
+@use "./mixins" as *;
+
 // Keyframes globales -----------------------------------------------------
 
 @keyframes entrar-abajo {
@@ -33,6 +35,15 @@
 @keyframes latido {
   0%, 100% { transform: scale(1); }
   50%      { transform: scale(1.25); }
+}
+
+@keyframes giro-spinner {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes fade-arriba {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 // Animaciones de carga (page load, sin scroll) ---------------------------
@@ -80,3 +91,64 @@
 .animar-hijos > *:nth-child(4) { animation-delay: 240ms; }
 .animar-hijos > *:nth-child(5) { animation-delay: 320ms; }
 .animar-hijos > *:nth-child(6) { animation-delay: 400ms; }
+
+// Spinner global de carga ------------------------------------------------
+//
+// Se renderiza con un solo div: el borde superior cyan/amarillo gira sobre
+// un círculo grisáceo. Las animaciones se quedan en transform/opacity para
+// que el navegador las componga en GPU.
+
+.spinner {
+  display: inline-block;
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 2px solid var(--borde-normal);
+  border-top-color: var(--amarillo-normal);
+  border-radius: var(--radius-full);
+  animation: giro-spinner 0.8s linear infinite;
+  vertical-align: middle;
+
+  &--grande { width: 2rem; height: 2rem; border-width: 3px; }
+  &--cyan   { border-top-color: var(--cyan-normal); }
+  &--verde  { border-top-color: var(--verde-normal); }
+}
+
+// Micro-interacción "fade desde abajo" para feedback puntual (toasts,
+// confirmaciones, item recién añadido). Más breve que .animar--subir.
+.aparecer {
+  animation: fade-arriba 0.32s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+// Accesibilidad: respetar la preferencia del sistema operativo de
+// reducir movimiento. Si el usuario ha activado "Reduce motion" en
+// macOS/Windows/Android/iOS, las animaciones de entrada y de scroll
+// reveal se desactivan completamente (queda solo el estado final
+// visible) y las transiciones bajan a una duración irrisoria.
+//
+// El uso de !important es legítimo aquí porque la preferencia del
+// usuario es la última palabra: gana sobre cualquier regla específica
+// que un componente pudiera redefinir.
+@include movimiento-reducido {
+  .animar,
+  .animar-hijos > *,
+  .revelar,
+  .aparecer {
+    animation: none !important;
+    transition: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+
+  .spinner {
+    animation-duration: 1.5s !important;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/autodeploy/src/styles/01-tools/_funciones.scss
+++ b/autodeploy/src/styles/01-tools/_funciones.scss
@@ -1,0 +1,65 @@
+// Tools: funciones Sass reutilizables.
+//
+// Las funciones se resuelven en compilación (a diferencia de var(--token),
+// que se resuelve en runtime). Sirven para encapsular lógica matemática y
+// devolver valores derivados: conversiones de unidades, mapeo de tokens y
+// generación de clamp() fluidos.
+
+@use 'sass:math';
+@use 'sass:map';
+@use 'sass:color';
+
+// ── Conversiones de unidades ─────────────────────────────────────────────
+
+// Convierte un número en píxeles a rem, asumiendo base 16. Uso: rem(24) → 1.5rem.
+@function rem($pixeles) {
+  @return math.div($pixeles, 16) * 1rem;
+}
+
+// Convierte píxeles a em respecto a un contexto. Útil para padding sensible
+// a la tipografía del propio elemento. Uso: em(12, 14) → 0.857em.
+@function em($pixeles, $contexto: 16) {
+  @return math.div($pixeles, $contexto) * 1em;
+}
+
+// ── Acceso seguro a mapas ─────────────────────────────────────────────────
+
+// Devuelve el valor de un mapa Sass o aborta con error si la clave no existe.
+// Sirve para escalas tipográficas o de espaciado que viven como mapas.
+@function tomar($mapa, $clave) {
+  @if not map.has-key($mapa, $clave) {
+    @error "La clave '#{$clave}' no existe en el mapa.";
+  }
+  @return map.get($mapa, $clave);
+}
+
+// ── Tipografía y espaciado fluido (clamp generado) ───────────────────────
+
+// Devuelve un clamp() que escala linealmente entre dos valores (mínimo y
+// máximo) en función del viewport, también acotado por dos breakpoints.
+// Uso típico: font-size: fluido(2.5rem, 4.5rem); para títulos hero.
+@function fluido($valor-min, $valor-max, $vp-min: 30rem, $vp-max: 80rem) {
+  $pendiente: math.div($valor-max - $valor-min, $vp-max - $vp-min);
+  $base: $valor-min - ($pendiente * $vp-min);
+  $vw: $pendiente * 100;
+  @return clamp(#{$valor-min}, #{$base} + #{$vw}vw, #{$valor-max});
+}
+
+// ── Atajos a Custom Properties (legibilidad en partials) ─────────────────
+
+@function token-color($nombre)    { @return var(--#{$nombre}); }
+@function token-espacio($nivel)   { @return var(--spacing-size-#{$nivel}); }
+@function token-radio($nivel)     { @return var(--radius-#{$nivel}); }
+@function token-sombra($nivel)    { @return var(--shadow-#{$nivel}); }
+@function token-z($capa)          { @return var(--z-#{$capa}); }
+@function token-duracion($vel)    { @return var(--duration-#{$vel}); }
+
+// ── Accesibilidad: color de texto sobre un fondo ─────────────────────────
+
+// Decide si poner texto claro u oscuro encima de un color HSL en función de
+// su luminosidad. Aproximación rápida al ratio WCAG; conviene afinarla con
+// WebAIM si el fondo está cerca del umbral.
+@function contraste-sobre($color) {
+  $luz: color.channel($color, "lightness", $space: hsl);
+  @return if($luz > 55%, hsl(0, 0%, 10%), hsl(0, 0%, 98%));
+}

--- a/autodeploy/src/styles/01-tools/_mixins.scss
+++ b/autodeploy/src/styles/01-tools/_mixins.scss
@@ -1,60 +1,77 @@
+// Tools: mixins reutilizables.
+//
+// Los mixins van aquí cuando encapsulan código que se repite en varios
+// componentes o cuando aceptan parámetros (@content, argumentos).
+// Para devolver un valor, usar @function en `_funciones.scss`.
+//
+// Categorías:
+//   1. Responsive (breakpoints viewport)
+//   2. Container queries (breakpoints contenedor)
+//   3. Preferencias del usuario (hover, motion, contraste, esquema)
+//   4. Layout (flex, grid, contenedor centrado)
+//   5. Tipografía y texto (truncar)
+//   6. Posicionamiento (centrado-absoluto)
+//   7. Accesibilidad (foco visible, visualmente oculto, disabled)
+//   8. Componentes base (tarjeta, tarjeta interactiva)
+//   9. Efectos (transición, glass, enlace subrayado)
+
 @use "../00-settings/css-variables" as *;
 
-@mixin movil-pequeno {
-  @media (max-width: $breakpoint-sm) {
-    @content;
-  }
-}
+// ── 1. Responsive (viewport) ─────────────────────────────────────────────
 
-@mixin movil {
-  @media (max-width: $breakpoint-md) {
-    @content;
-  }
-}
-
-@mixin tablet {
-  @media (max-width: $breakpoint-lg) {
-    @content;
-  }
-}
-
-@mixin escritorio {
-  @media (min-width: $breakpoint-lg) {
-    @content;
-  }
-}
-
-@mixin escritorio-grande {
-  @media (min-width: $breakpoint-xl) {
-    @content;
-  }
-}
-
+@mixin movil-pequeno     { @media (max-width: $breakpoint-sm) { @content; } }
+@mixin movil             { @media (max-width: $breakpoint-md) { @content; } }
+@mixin tablet            { @media (max-width: $breakpoint-lg) { @content; } }
+@mixin escritorio        { @media (min-width: $breakpoint-lg) { @content; } }
+@mixin escritorio-grande { @media (min-width: $breakpoint-xl) { @content; } }
 @mixin entre($desde, $hasta) {
-  @media (min-width: $desde) and (max-width: $hasta) {
-    @content;
-  }
+  @media (min-width: $desde) and (max-width: $hasta) { @content; }
 }
 
-@mixin solo-tactil {
-  @media (hover: none) and (pointer: coarse) {
-    @content;
-  }
+// ── 2. Container queries (ancho del contenedor padre) ────────────────────
+//
+// Para usarlos, el padre debe tener container-type: inline-size y un
+// container-name (opcional). Sirven cuando un componente reutilizable
+// (tarjeta, lista) tiene que adaptarse según el ancho del contenedor en
+// el que se inserta, no según el viewport.
+
+@mixin contenedor-pequeno { @container (max-width: 28rem) { @content; } }
+@mixin contenedor-mediano { @container (min-width: 28rem) and (max-width: 48rem) { @content; } }
+@mixin contenedor-grande  { @container (min-width: 48rem) { @content; } }
+
+// ── 3. Preferencias del usuario ──────────────────────────────────────────
+
+@mixin solo-tactil        { @media (hover: none) and (pointer: coarse) { @content; } }
+@mixin solo-puntero-fino  { @media (hover: hover) and (pointer: fine)  { @content; } }
+@mixin movimiento-reducido { @media (prefers-reduced-motion: reduce)   { @content; } }
+@mixin contraste-alto     { @media (prefers-contrast: more)            { @content; } }
+@mixin esquema-claro      { @media (prefers-color-scheme: light)       { @content; } }
+@mixin esquema-oscuro     { @media (prefers-color-scheme: dark)        { @content; } }
+
+// ── 4. Layout ────────────────────────────────────────────────────────────
+
+@mixin flex-centro     { display: flex; align-items: center; justify-content: center; }
+@mixin flex-entre      { display: flex; align-items: center; justify-content: space-between; }
+@mixin flex-columna    { display: flex; flex-direction: column; }
+@mixin flex-envoltura  { display: flex; flex-wrap: wrap; }
+
+// Grid responsivo sin media queries: la cuadrícula reflowa por sí sola
+// gracias a auto-fit + minmax. $min es el ancho mínimo de cada columna.
+@mixin grid-auto($min: 16rem, $hueco: var(--spacing-size-2xl)) {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax($min, 1fr));
+  gap: $hueco;
 }
 
-@mixin movimiento-reducido {
-  @media (prefers-reduced-motion: reduce) {
-    @content;
-  }
+// Contenedor centrado con ancho máximo y padding interior.
+@mixin contenedor($ancho: 75rem) {
+  width: 100%;
+  max-width: $ancho;
+  margin-inline: auto;
+  padding-inline: var(--spacing-size-2xl);
 }
 
-@mixin foco-visible {
-  &:focus-visible {
-    outline: 2px solid var(--amarillo-normal);
-    outline-offset: 2px;
-    @content;
-  }
-}
+// ── 5. Tipografía y texto ────────────────────────────────────────────────
 
 @mixin truncar($lineas: 1) {
   display: -webkit-box;
@@ -64,6 +81,8 @@
   text-overflow: ellipsis;
 }
 
+// ── 6. Posicionamiento ───────────────────────────────────────────────────
+
 @mixin centrado-absoluto {
   position: absolute;
   top: 50%;
@@ -71,9 +90,106 @@
   transform: translate(-50%, -50%);
 }
 
+// ── 7. Accesibilidad ─────────────────────────────────────────────────────
+
+@mixin foco-visible {
+  &:focus-visible {
+    outline: 2px solid var(--amarillo-normal);
+    outline-offset: 2px;
+    @content;
+  }
+}
+
+// Oculta visualmente pero deja accesible para lectores de pantalla.
+// Patrón "sr-only". Útil para etiquetas que dan contexto sin ruido visual.
+@mixin visualmente-oculto {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+// Estado deshabilitado coherente para botones, inputs y enlaces.
+@mixin disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+// ── 8. Componentes base ──────────────────────────────────────────────────
+
 @mixin tarjeta-base {
   background-color: var(--fondo-tarjeta);
   border: 1px solid var(--borde-normal);
   border-radius: var(--radius-l);
   padding: var(--spacing-size-2xl);
+}
+
+// Tarjeta interactiva: combina tarjeta-base con transición, hover y foco
+// teclado. Se usa donde la tarjeta es clickable (enlace o botón completo).
+@mixin tarjeta-interactiva {
+  @include tarjeta-base;
+  @include transicion(transform, box-shadow, border-color);
+  cursor: pointer;
+
+  &:hover {
+    transform: translateY(-0.125rem);
+    box-shadow: var(--shadow-hover-amarillo);
+    border-color: var(--amarillo-normal-hover);
+  }
+  &:focus-within {
+    outline: 2px solid var(--amarillo-normal);
+    outline-offset: 2px;
+  }
+}
+
+// ── 9. Efectos ───────────────────────────────────────────────────────────
+
+// Genera una transition con el timing function estándar del proyecto.
+// Acepta varias propiedades y las une con coma.
+@mixin transicion($propiedades...) {
+  $resultado: ();
+  @each $prop in $propiedades {
+    $resultado: append(
+      $resultado,
+      #{$prop} var(--duration-base) cubic-bezier(0.16, 1, 0.3, 1),
+      $separator: comma
+    );
+  }
+  transition: $resultado;
+}
+
+// Fondo translucido con desenfoque (cabeceras, modales).
+@mixin glass($fondo: var(--fondo-cabecera)) {
+  background-color: $fondo;
+  backdrop-filter: blur(0.625rem);
+  -webkit-backdrop-filter: blur(0.625rem);
+}
+
+// Enlace con subrayado animado desde la derecha al hacer hover/foco.
+@mixin enlace-subrayado {
+  position: relative;
+  text-decoration: none;
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: auto 0 -2px 0;
+    height: 2px;
+    background-color: currentColor;
+    transform: scaleX(0);
+    transform-origin: right;
+    @include transicion(transform);
+  }
+
+  &:hover::after,
+  &:focus-visible::after {
+    transform: scaleX(1);
+    transform-origin: left;
+  }
 }

--- a/autodeploy/src/styles/02-generic/_design-tokens.scss
+++ b/autodeploy/src/styles/02-generic/_design-tokens.scss
@@ -24,10 +24,15 @@
   --amarillo-normal: hsl(47, 86%, 56%);
   --amarillo-normal-hover: hsl(45, 78%, 48%);
 
-  /* === TEXTOS === */
+  /* === TEXTOS ===
+   * Contrastes verificados sobre --fondo-tarjeta (L=16%) para WCAG 2.1 AA:
+   *   --texto-claro    L=91% → ratio ~11.6:1 (AAA)
+   *   --texto-medio    L=63% → ratio  ~5.3:1 (AA)
+   *   --texto-apagado  L=60% → ratio  ~4.7:1 (AA, antes 40%/~2.4:1 fallaba)
+   */
   --texto-claro: hsl(40, 33.33%, 91.37%);
   --texto-medio: hsl(30, 5.08%, 63.14%);
-  --texto-apagado: hsl(33, 4.12%, 40%);
+  --texto-apagado: hsl(33, 5%, 60%);
 
   /* === BORDES === */
   --borde-normal: hsla(40, 33.33%, 91.37%, 0.08);
@@ -141,9 +146,14 @@
   --fondo-negro-medio: hsl(40, 8%, 93%);
   --fondo-cta-claro: hsl(34, 17.65%, 83.73%);
 
+  /* Contrastes sobre el fondo claro (L=96%):
+   *   --texto-claro    L=12% → ratio ~14.4:1 (AAA)
+   *   --texto-medio    L=38% → ratio  ~5.5:1 (AA, antes ya pasaba)
+   *   --texto-apagado  L=42% → ratio  ~4.6:1 (AA, antes 56%/~3.2:1 fallaba)
+   */
   --texto-claro: hsl(30, 12%, 12%);
   --texto-medio: hsl(30, 5%, 38%);
-  --texto-apagado: hsl(30, 3%, 56%);
+  --texto-apagado: hsl(30, 4%, 42%);
 
   --borde-normal: hsla(30, 10%, 12%, 0.12);
   --borde-suave: hsla(30, 10%, 12%, 0.07);

--- a/autodeploy/src/styles/02-generic/_reset.scss
+++ b/autodeploy/src/styles/02-generic/_reset.scss
@@ -13,6 +13,10 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
+  // Transición global suave al alternar tema (clase .tema-claro en <html>).
+  // El @include movimiento-reducido del partial _animaciones.scss anula
+  // esto cuando el usuario tiene prefers-reduced-motion: reduce.
+  transition: background-color var(--duration-base) ease, color var(--duration-base) ease;
 }
 
 ul {

--- a/autodeploy/src/styles/03-elements/_buttons.scss
+++ b/autodeploy/src/styles/03-elements/_buttons.scss
@@ -1,84 +1,82 @@
-.boton--primario {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+@use "../01-tools/mixins" as *;
+
+// Propiedades comunes a todas las variantes de botón. Se extiende con
+// %placeholder para no generar selectores extra en el CSS final.
+%boton-base {
+  @include flex-centro;
   gap: 0.5rem;
   padding: 0.625rem 1.5rem;
-  background-color: var(--amarillo-normal);
-  color: var(--fondo-oscuro);
   font-size: var(--font-size-md);
-  font-weight: var(--font-weight-bold);
-  border: none;
   border-radius: var(--radius-l);
   cursor: pointer;
-  transition: background-color var(--duration-base) ease, transform var(--duration-fast) ease;
+  @include transicion(background-color, border-color, color, transform);
 }
 
-.boton--primario:hover {
-  background-color: var(--amarillo-normal-hover);
-}
+.boton {
+  &--primario {
+    @extend %boton-base;
+    background-color: var(--amarillo-normal);
+    color: var(--fondo-oscuro);
+    font-weight: var(--font-weight-bold);
+    border: none;
 
-.boton--primario:active {
-  transform: scale(0.98);
-}
+    &:hover     { background-color: var(--amarillo-normal-hover); }
+    &:active    { transform: scale(0.98); }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled  { @include disabled; }
+  }
 
-.boton--secundario {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 0.625rem 1.5rem;
-  background: rgba(240, 236, 226, 0.03);
-  color: var(--texto-claro);
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-semibold);
-  border: 1px solid var(--borde-normal);
-  border-radius: var(--radius-l);
-  cursor: pointer;
-  transition: border-color var(--duration-base) ease;
-}
+  &--secundario {
+    @extend %boton-base;
+    background: rgba(240, 236, 226, 0.03);
+    color: var(--texto-claro);
+    font-weight: var(--font-weight-semibold);
+    border: 1px solid var(--borde-normal);
 
-.boton--secundario:hover {
-  border-color: rgba(240, 236, 226, 0.2);
-}
+    &:hover     { border-color: rgba(240, 236, 226, 0.2); }
+    &:active    { transform: scale(0.98); }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled  { @include disabled; }
+  }
 
-.boton--ghost {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 0.625rem 1.5rem;
-  background: transparent;
-  color: var(--texto-medio);
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-semibold);
-  border: 1px solid var(--borde-normal);
-  border-radius: var(--radius-l);
-  cursor: pointer;
-  transition: color var(--duration-base) ease, border-color var(--duration-base) ease;
-}
+  &--ghost {
+    @extend %boton-base;
+    background: transparent;
+    color: var(--texto-medio);
+    font-weight: var(--font-weight-semibold);
+    border: 1px solid var(--borde-normal);
 
-.boton--ghost:hover {
-  color: var(--texto-claro);
-  border-color: rgba(240, 236, 226, 0.2);
-}
+    &:hover {
+      color: var(--texto-claro);
+      border-color: rgba(240, 236, 226, 0.2);
+    }
+    &:active    { transform: scale(0.98); }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled  { @include disabled; }
+  }
 
-.boton--peligro {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 0.625rem 1.5rem;
-  background: rgba(239, 68, 68, 0.08);
-  color: var(--rojo-normal);
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-semibold);
-  border: 1px solid rgba(239, 68, 68, 0.15);
-  border-radius: var(--radius-l);
-  cursor: pointer;
-  transition: background-color var(--duration-base) ease;
-}
+  &--peligro {
+    @extend %boton-base;
+    background: rgba(239, 68, 68, 0.08);
+    color: var(--rojo-normal);
+    font-weight: var(--font-weight-semibold);
+    border: 1px solid rgba(239, 68, 68, 0.15);
 
-.boton--peligro:hover {
-  background: rgba(239, 68, 68, 0.15);
+    &:hover     { background: rgba(239, 68, 68, 0.15); }
+    &:active    { transform: scale(0.98); }
+    &:focus-visible {
+      outline: 2px solid var(--rojo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled  { @include disabled; }
+  }
 }

--- a/autodeploy/src/styles/03-elements/_forms.scss
+++ b/autodeploy/src/styles/03-elements/_forms.scss
@@ -1,83 +1,90 @@
+@use "../01-tools/mixins" as *;
+
 .campo {
-  display: flex;
-  flex-direction: column;
+  @include flex-columna;
   gap: 0.375rem;
-}
 
-.campo__etiqueta {
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-bold);
-  text-transform: uppercase;
-  letter-spacing: 1.5px;
-  color: var(--texto-apagado);
-}
+  &__etiqueta {
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-bold);
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: var(--texto-apagado);
+  }
 
-.campo__input {
-  padding: 0.625rem var(--spacing-size-l);
-  background: rgba(240, 236, 226, 0.03);
-  border: 1px solid var(--borde-normal);
-  border-radius: var(--radius-m);
-  color: var(--texto-claro);
-  font-family: var(--font-primary);
-  font-size: var(--font-size-md);
-  transition: border-color var(--duration-base) ease;
-}
+  &__input {
+    padding: 0.625rem var(--spacing-size-l);
+    background: rgba(240, 236, 226, 0.03);
+    border: 1px solid var(--borde-normal);
+    border-radius: var(--radius-m);
+    color: var(--texto-claro);
+    font-family: var(--font-primary);
+    font-size: var(--font-size-md);
+    @include transicion(border-color);
 
-.campo__input::placeholder {
-  color: var(--texto-apagado);
-}
+    &::placeholder { color: var(--texto-apagado); }
 
-.campo__input:focus {
-  outline: none;
-  border-color: var(--amarillo-normal);
-}
+    &:focus {
+      outline: none;
+      border-color: var(--amarillo-normal);
+    }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled { @include disabled; }
+    &:invalid:not(:focus) { border-color: var(--rojo-normal); }
+  }
 
-.campo__input:focus-visible {
-  outline: 2px solid var(--amarillo-normal);
-  outline-offset: 2px;
-}
+  &__textarea {
+    padding: 0.625rem var(--spacing-size-l);
+    background: rgba(240, 236, 226, 0.03);
+    border: 1px solid var(--borde-normal);
+    border-radius: var(--radius-m);
+    color: var(--texto-claro);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-sm);
+    resize: vertical;
+    @include transicion(border-color);
 
-.campo__textarea {
-  padding: 0.625rem var(--spacing-size-l);
-  background: rgba(240, 236, 226, 0.03);
-  border: 1px solid var(--borde-normal);
-  border-radius: var(--radius-m);
-  color: var(--texto-claro);
-  font-family: var(--font-mono);
-  font-size: var(--font-size-sm);
-  resize: vertical;
-  transition: border-color var(--duration-base) ease;
-}
+    &::placeholder { color: var(--texto-apagado); }
 
-.campo__textarea::placeholder {
-  color: var(--texto-apagado);
-}
+    &:focus {
+      outline: none;
+      border-color: var(--amarillo-normal);
+    }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled { @include disabled; }
+    &:invalid:not(:focus) { border-color: var(--rojo-normal); }
+  }
 
-.campo__textarea:focus {
-  outline: none;
-  border-color: var(--amarillo-normal);
-}
+  &__pista {
+    font-size: var(--font-size-xs);
+    color: var(--texto-apagado);
+  }
 
-.campo__textarea:focus-visible {
-  outline: 2px solid var(--amarillo-normal);
-  outline-offset: 2px;
-}
+  &__select {
+    padding: 0.625rem var(--spacing-size-l);
+    background: rgba(240, 236, 226, 0.03);
+    border: 1px solid var(--borde-normal);
+    border-radius: var(--radius-m);
+    color: var(--texto-claro);
+    font-family: var(--font-primary);
+    font-size: var(--font-size-md);
+    appearance: none;
+    cursor: pointer;
+    @include transicion(border-color);
 
-.campo__pista {
-  font-size: var(--font-size-xs);
-  color: var(--texto-apagado);
-}
-
-.campo__select {
-  padding: 0.625rem var(--spacing-size-l);
-  background: rgba(240, 236, 226, 0.03);
-  border: 1px solid var(--borde-normal);
-  border-radius: var(--radius-m);
-  color: var(--texto-claro);
-  font-family: var(--font-primary);
-  font-size: var(--font-size-md);
-  appearance: none;
-  cursor: pointer;
+    &:focus { outline: none; border-color: var(--amarillo-normal); }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: 2px;
+    }
+    &:disabled { @include disabled; }
+  }
 }
 
 .toggle {
@@ -85,23 +92,30 @@
   border: 1px solid var(--borde-normal);
   border-radius: var(--radius-m);
   overflow: hidden;
-}
 
-.toggle__opcion {
-  padding: 0.5rem 1.25rem;
-  background: transparent;
-  color: var(--texto-medio);
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-semibold);
-  border: none;
-  cursor: pointer;
-  transition: background-color var(--duration-base) ease, color var(--duration-base) ease;
-}
+  &__opcion {
+    padding: 0.5rem 1.25rem;
+    background: transparent;
+    color: var(--texto-medio);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+    border: none;
+    cursor: pointer;
+    @include transicion(background-color, color);
 
-.toggle__opcion--activa {
-  background-color: rgba(245, 214, 35, 0.1);
-  color: var(--amarillo-normal);
-  border-left: 2px solid var(--amarillo-normal);
+    &--activa {
+      background-color: rgba(245, 214, 35, 0.1);
+      color: var(--amarillo-normal);
+      border-left: 2px solid var(--amarillo-normal);
+    }
+
+    &:hover:not(&--activa) { color: var(--texto-claro); }
+    &:focus-visible {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: -2px;
+    }
+    &:disabled { @include disabled; }
+  }
 }
 
 .interruptor {
@@ -113,29 +127,26 @@
   padding: 0;
   border-radius: var(--radius-full);
   cursor: pointer;
-  transition: background-color var(--duration-base) ease;
-}
+  @include transicion(background-color);
 
-.interruptor:focus-visible {
-  outline: 2px solid var(--amarillo-normal);
-  outline-offset: 2px;
-}
+  &--activo { background-color: var(--amarillo-normal); }
 
-.interruptor--activo {
-  background-color: var(--amarillo-normal);
-}
+  &:focus-visible {
+    outline: 2px solid var(--amarillo-normal);
+    outline-offset: 2px;
+  }
+  &:disabled { @include disabled; }
 
-.interruptor__circulo {
-  position: absolute;
-  top: 0.1875rem;
-  left: 0.1875rem;
-  width: 1.125rem;
-  height: 1.125rem;
-  background-color: white;
-  border-radius: 50%;
-  transition: transform var(--duration-base) ease;
-}
+  &__circulo {
+    position: absolute;
+    top: 0.1875rem;
+    left: 0.1875rem;
+    width: 1.125rem;
+    height: 1.125rem;
+    background-color: white;
+    border-radius: 50%;
+    @include transicion(transform);
 
-.interruptor__circulo--activo {
-  transform: translateX(1.25rem);
+    &--activo { transform: translateX(1.25rem); }
+  }
 }

--- a/autodeploy/src/styles/04-layout/_layout.scss
+++ b/autodeploy/src/styles/04-layout/_layout.scss
@@ -21,8 +21,16 @@
   display: none;
 }
 
+// El backdrop es un <button type="button"> (semánticamente: control que
+// cierra el menú al pulsar fuera). Hay que resetear los estilos por
+// defecto del botón para que actúe como una capa transparente.
 .disposicion-app__backdrop {
   display: none;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  cursor: pointer;
+  appearance: none;
 }
 
 @media (max-width: 768px) {

--- a/autodeploy/src/styles/05-components/_barra-lateral.scss
+++ b/autodeploy/src/styles/05-components/_barra-lateral.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .barra-lateral {
   position: sticky;
   top: 0;
@@ -25,7 +27,7 @@
     pointer-events: none;
   }
 
-  @media (max-width: 768px) {
+  @include movil {
     position: fixed;
     top: 0;
     left: 0;
@@ -459,7 +461,7 @@
 
   // ───── Modificador: abierta (mobile) ─────
   &--abierta {
-    @media (max-width: 768px) {
+    @include movil {
       transform: translateX(0);
     }
   }

--- a/autodeploy/src/styles/05-components/_barra-lateral.scss
+++ b/autodeploy/src/styles/05-components/_barra-lateral.scss
@@ -183,7 +183,13 @@
       outline-offset: -2px;
     }
 
-    &--activo {
+    // El estado "página activa" se aplica tanto por la clase BEM
+    // --activo (puesta por routerLinkActive de Angular) como por el
+    // atributo aria-current="page", que es el que leen los lectores
+    // de pantalla. Ambos selectores se mantienen para que la regla
+    // funcione aunque sólo se use uno de los dos enfoques.
+    &--activo,
+    &[aria-current="page"] {
       color: var(--amarillo-normal);
       background: linear-gradient(90deg, hsla(47, 86%, 56%, 0.08), transparent 70%);
 

--- a/autodeploy/src/styles/05-components/_galeria-capturas.scss
+++ b/autodeploy/src/styles/05-components/_galeria-capturas.scss
@@ -1,0 +1,80 @@
+@use "../01-tools/mixins" as *;
+
+.galeria-capturas {
+  @include flex-columna;
+  gap: var(--spacing-size-2xl);
+
+  &__lista {
+    list-style: none;
+    @include grid-auto(18rem, var(--spacing-size-2xl));
+  }
+
+  &__item {
+    container-type: inline-size;
+    container-name: galeria-captura;
+  }
+
+  &__figura {
+    @include flex-columna;
+    gap: var(--spacing-size-m);
+    margin: 0;
+    padding: var(--spacing-size-l);
+    background: var(--fondo-tarjeta);
+    border: 1px solid var(--borde-normal);
+    border-radius: var(--radius-l);
+    overflow: hidden;
+    @include transicion(transform, box-shadow, border-color);
+
+    &:hover {
+      transform: translateY(-0.125rem);
+      box-shadow: var(--shadow-hover-amarillo);
+      border-color: var(--amarillo-normal-hover);
+    }
+
+    &:focus-within {
+      outline: 2px solid var(--amarillo-normal);
+      outline-offset: 2px;
+    }
+  }
+
+  &__imagen {
+    width: 100%;
+    height: auto;
+    border-radius: var(--radius-m);
+    aspect-ratio: 16 / 10;
+    object-fit: cover;
+    display: block;
+  }
+
+  &__caption {
+    font-size: var(--font-size-md);
+    font-weight: var(--font-weight-semibold);
+    color: var(--texto-claro);
+    line-height: var(--line-height-tight);
+  }
+
+  // Estado vacío (sin capturas) -------------------------------------------
+  &__placeholder {
+    grid-column: 1 / -1;
+    padding: var(--spacing-size-3xl);
+    background: rgba(240, 236, 226, 0.02);
+    border: 1px dashed var(--borde-normal);
+    border-radius: var(--radius-l);
+    text-align: center;
+    color: var(--texto-medio);
+
+    code {
+      font-family: var(--font-mono);
+      color: var(--amarillo-normal);
+    }
+  }
+
+  // En contenedores estrechos (sidebar, modal lateral) la galería pasa a
+  // una sola columna automáticamente gracias a auto-fit del grid; cuando
+  // hay espacio, los figcaption pasan a una tipografía más holgada.
+  @container galeria-captura (min-width: 24rem) {
+    &__caption {
+      font-size: var(--font-size-lg);
+    }
+  }
+}

--- a/autodeploy/src/styles/05-components/_gestion-servidor.scss
+++ b/autodeploy/src/styles/05-components/_gestion-servidor.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .gestion-servidor {
   display: flex;
   flex-direction: column;
@@ -15,7 +17,7 @@
     letter-spacing: 0.04em;
     color: var(--texto-medio);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-wrap: wrap;
     }
   }
@@ -41,7 +43,7 @@
     align-items: flex-start;
     justify-content: space-between;
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: var(--spacing-size-l);
@@ -105,7 +107,7 @@
     align-items: center;
     justify-content: space-between;
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: var(--spacing-size-l);
@@ -135,7 +137,7 @@
       border-color: var(--amarillo-normal);
     }
 
-    @media (max-width: 768px) {
+    @include movil {
       min-width: unset;
       width: 100%;
     }
@@ -201,7 +203,7 @@
     display: flex;
     gap: var(--spacing-size-l);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
     }
 
@@ -262,7 +264,7 @@
       outline-offset: 2px;
     }
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: var(--spacing-size-l);
@@ -368,7 +370,7 @@
     display: flex;
     gap: var(--spacing-size-l);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
     }
   }
@@ -491,7 +493,7 @@
     padding: var(--spacing-size-2xl);
     border-top: 1px solid var(--borde-normal);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-wrap: wrap;
       gap: var(--spacing-size-l);
     }

--- a/autodeploy/src/styles/05-components/_logs-terminal.scss
+++ b/autodeploy/src/styles/05-components/_logs-terminal.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .logs-terminal {
   display: flex;
   flex-direction: column;
@@ -7,7 +9,7 @@
   &__cabecera {
     align-items: flex-end;
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: var(--spacing-size-l);
@@ -24,7 +26,7 @@
       align-items: center;
       gap: var(--spacing-size-l);
 
-      @media (max-width: 768px) {
+      @include movil {
         flex-wrap: wrap;
         gap: var(--spacing-size-m);
       }
@@ -64,7 +66,7 @@
       border-color: var(--amarillo-normal);
     }
 
-    @media (max-width: 768px) {
+    @include movil {
       min-width: unset;
       width: 100%;
     }
@@ -101,7 +103,7 @@
     align-items: center;
     justify-content: space-between;
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: var(--spacing-size-m);
@@ -113,7 +115,7 @@
     align-items: center;
     gap: 0.25rem;
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-wrap: wrap;
     }
   }

--- a/autodeploy/src/styles/05-components/_nuevo-despliegue.scss
+++ b/autodeploy/src/styles/05-components/_nuevo-despliegue.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .nuevo-despliegue {
   display: flex;
   flex-direction: column;
@@ -8,7 +10,7 @@
     align-items: center;
     justify-content: space-between;
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: var(--spacing-size-l);
@@ -70,7 +72,7 @@
     display: flex;
     gap: var(--spacing-size-l);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
     }
 
@@ -136,7 +138,7 @@
     display: flex;
     gap: var(--spacing-size-3xl);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
     }
   }
@@ -145,7 +147,7 @@
     display: flex;
     gap: var(--spacing-size-l);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
     }
   }
@@ -255,7 +257,7 @@
     padding-top: var(--spacing-size-2xl);
     border-top: 1px solid var(--borde-normal);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column-reverse;
     }
   }

--- a/autodeploy/src/styles/05-components/_pagina-comunidad.scss
+++ b/autodeploy/src/styles/05-components/_pagina-comunidad.scss
@@ -1,4 +1,5 @@
 @use "../00-settings/css-variables" as *;
+@use "../01-tools/mixins" as *;
 
 .pagina-comunidad {
   &__canales {
@@ -111,7 +112,7 @@
     border: 1px solid var(--borde-normal);
     border-radius: var(--radius-2xl);
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       padding: var(--spacing-size-3xl) var(--spacing-size-l);
     }
 

--- a/autodeploy/src/styles/05-components/_pagina-contacto.scss
+++ b/autodeploy/src/styles/05-components/_pagina-contacto.scss
@@ -1,4 +1,5 @@
 @use "../00-settings/css-variables" as *;
+@use "../01-tools/mixins" as *;
 
 .pagina-contacto {
   display: grid;
@@ -18,7 +19,7 @@
     border: 1px solid var(--borde-normal);
     border-radius: var(--radius-xl);
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       padding: var(--spacing-size-2xl);
     }
   }
@@ -134,7 +135,7 @@
     border-radius: var(--radius-xl);
     height: fit-content;
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       padding: var(--spacing-size-2xl);
     }
   }

--- a/autodeploy/src/styles/05-components/_pagina-documentacion.scss
+++ b/autodeploy/src/styles/05-components/_pagina-documentacion.scss
@@ -1,4 +1,4 @@
-@use "../00-settings/css-variables" as *;
+@use "../01-tools/mixins" as *;
 
 .pagina-documentacion {
   &__categoria {
@@ -13,7 +13,7 @@
       gap: 0.25rem var(--spacing-size-m);
       align-items: center;
 
-      @media (max-width: $breakpoint-md) {
+      @include movil {
         grid-template-columns: 1fr;
       }
     }
@@ -31,7 +31,7 @@
       display: flex;
       align-items: center;
 
-      @media (max-width: $breakpoint-md) {
+      @include movil {
         grid-row: auto;
         width: fit-content;
       }
@@ -82,7 +82,7 @@
       padding-left: var(--spacing-size-m);
     }
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       grid-template-columns: auto 1fr;
       gap: var(--spacing-size-m);
     }
@@ -125,7 +125,7 @@
       border-radius: var(--radius-full);
       white-space: nowrap;
 
-      @media (max-width: $breakpoint-md) {
+      @include movil {
         grid-column: 2 / -1;
         justify-self: start;
         margin-top: var(--spacing-size-xs);

--- a/autodeploy/src/styles/05-components/_pagina-estado.scss
+++ b/autodeploy/src/styles/05-components/_pagina-estado.scss
@@ -1,4 +1,4 @@
-@use "../00-settings/css-variables" as *;
+@use "../01-tools/mixins" as *;
 
 .pagina-estado {
   &__banner {
@@ -85,7 +85,7 @@
       background-color: rgba(240, 236, 226, 0.03);
     }
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       padding: var(--spacing-size-m) var(--spacing-size-l);
       gap: var(--spacing-size-m);
     }
@@ -124,7 +124,7 @@
       font-weight: var(--font-weight-semibold);
       color: var(--texto-claro);
 
-      @media (max-width: $breakpoint-md) {
+      @include movil {
         font-size: var(--font-size-md);
       }
     }

--- a/autodeploy/src/styles/05-components/_pagina-legal.scss
+++ b/autodeploy/src/styles/05-components/_pagina-legal.scss
@@ -1,9 +1,11 @@
+@use "../01-tools/mixins" as *;
+
 .pagina-legal {
   background-color: var(--fondo-oscuro);
   min-height: calc(100vh - 3.5rem);
   padding: var(--spacing-size-6xl) var(--spacing-size-3xl);
 
-  @media (max-width: 768px) {
+  @include movil {
     padding: var(--spacing-size-4xl) var(--spacing-size-2xl);
   }
 
@@ -20,7 +22,7 @@
     margin-bottom: var(--spacing-size-s);
     line-height: var(--line-height-tight);
 
-    @media (max-width: 768px) {
+    @include movil {
       font-size: var(--font-size-3xl);
     }
   }
@@ -83,7 +85,7 @@
     border-radius: var(--radius-m);
     overflow: hidden;
 
-    @media (max-width: 768px) {
+    @include movil {
       display: block;
       overflow-x: auto;
     }

--- a/autodeploy/src/styles/05-components/_pagina-login.scss
+++ b/autodeploy/src/styles/05-components/_pagina-login.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/funciones" as *;
+
 .pagina-login {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
@@ -72,7 +74,9 @@
 
     &__titular {
       font-family: var(--font-secondary);
-      font-size: clamp(2.5rem, 5vw, 3.75rem);
+      // Generado con la función fluido() (equivalente al clamp manual,
+      // pero declarativo y reusable).
+      font-size: fluido(2.5rem, 3.75rem);
       font-weight: var(--font-weight-bold);
       letter-spacing: -0.045em;
       line-height: 0.95;

--- a/autodeploy/src/styles/05-components/_pagina-recursos.scss
+++ b/autodeploy/src/styles/05-components/_pagina-recursos.scss
@@ -1,4 +1,4 @@
-@use "../00-settings/css-variables" as *;
+@use "../01-tools/mixins" as *;
 
 .pagina-recursos {
   background-color: var(--fondo-oscuro);
@@ -10,7 +10,7 @@
   max-width: 72rem;
   margin: 0 auto;
 
-  @media (max-width: $breakpoint-md) {
+  @include movil {
     padding: var(--spacing-size-4xl) var(--spacing-size-l);
   }
 
@@ -22,7 +22,7 @@
     padding-bottom: var(--spacing-size-3xl);
     border-bottom: 1px solid var(--borde-normal);
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       grid-template-columns: 1fr;
       align-items: flex-start;
     }
@@ -40,7 +40,7 @@
       gap: 0.25rem;
       text-align: right;
 
-      @media (max-width: $breakpoint-md) {
+      @include movil {
         align-items: flex-start;
         text-align: left;
       }
@@ -103,7 +103,7 @@
     grid-template-columns: repeat(2, 1fr);
     gap: var(--spacing-size-2xl);
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       grid-template-columns: 1fr;
     }
   }
@@ -130,7 +130,7 @@
       outline-offset: 2px;
     }
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       padding: var(--spacing-size-2xl);
     }
 
@@ -201,7 +201,7 @@
     color: var(--texto-claro);
     flex-wrap: wrap;
 
-    @media (max-width: $breakpoint-md) {
+    @include movil {
       gap: var(--spacing-size-s);
     }
 
@@ -226,7 +226,7 @@
       font-size: var(--font-size-md);
       margin-left: auto;
 
-      @media (max-width: $breakpoint-md) {
+      @include movil {
         margin-left: 0;
         width: 100%;
       }

--- a/autodeploy/src/styles/05-components/_pagina-style-guide.scss
+++ b/autodeploy/src/styles/05-components/_pagina-style-guide.scss
@@ -1,0 +1,292 @@
+@use "../01-tools/mixins" as *;
+@use "../01-tools/funciones" as *;
+
+.pagina-style-guide {
+  @include contenedor(64rem);
+  padding-block: var(--spacing-size-6xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-size-7xl);
+
+  &__cabecera {
+    @include flex-columna;
+    gap: var(--spacing-size-l);
+    padding-bottom: var(--spacing-size-3xl);
+    border-bottom: 1px solid var(--borde-normal);
+  }
+
+  &__superior {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    color: var(--texto-apagado);
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+  }
+
+  &__titulo {
+    font-family: var(--font-secondary);
+    font-size: fluido(2rem, 3rem);
+    font-weight: var(--font-weight-bold);
+    line-height: var(--line-height-tight);
+    color: var(--texto-claro);
+    letter-spacing: -0.03em;
+  }
+
+  &__intro {
+    max-width: 42rem;
+    font-size: var(--font-size-lg);
+    line-height: var(--line-height-relaxed);
+    color: var(--texto-medio);
+  }
+
+  // Índice flotante ---------------------------------------------------------
+  &__indice {
+    position: sticky;
+    top: var(--spacing-size-2xl);
+    align-self: flex-start;
+    padding: var(--spacing-size-l) var(--spacing-size-2xl);
+    background: var(--fondo-tarjeta);
+    border: 1px solid var(--borde-normal);
+    border-radius: var(--radius-l);
+    z-index: 1;
+  }
+
+  &__indice-lista {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-size-m) var(--spacing-size-2xl);
+    list-style: decimal-leading-zero inside;
+    color: var(--texto-medio);
+    counter-reset: indice;
+
+    a {
+      color: var(--texto-medio);
+      @include transicion(color);
+
+      &:hover { color: var(--texto-claro); }
+      &:focus-visible {
+        outline: 2px solid var(--amarillo-normal);
+        outline-offset: 2px;
+        border-radius: var(--radius-xs);
+      }
+    }
+  }
+
+  // Bloques de sección ------------------------------------------------------
+  &__seccion {
+    @include flex-columna;
+    gap: var(--spacing-size-3xl);
+
+    &__cabecera {
+      @include flex-columna;
+      gap: var(--spacing-size-s);
+      padding-bottom: var(--spacing-size-2xl);
+      border-bottom: 1px solid var(--borde-suave);
+    }
+
+    &__numero {
+      font-family: var(--font-mono);
+      font-size: var(--font-size-xs);
+      color: var(--amarillo-normal);
+      letter-spacing: 0.2em;
+    }
+
+    &__titulo {
+      font-family: var(--font-secondary);
+      font-size: var(--font-size-3xl);
+      font-weight: var(--font-weight-bold);
+      color: var(--texto-claro);
+      line-height: var(--line-height-tight);
+    }
+
+    &__descripcion {
+      font-size: var(--font-size-base);
+      line-height: var(--line-height-relaxed);
+      color: var(--texto-medio);
+      max-width: 44rem;
+    }
+  }
+
+  &__bloque {
+    @include flex-columna;
+    gap: var(--spacing-size-l);
+    padding: var(--spacing-size-2xl);
+    background: var(--fondo-tarjeta);
+    border: 1px solid var(--borde-normal);
+    border-radius: var(--radius-l);
+
+    &__titulo {
+      font-size: var(--font-size-lg);
+      font-weight: var(--font-weight-semibold);
+      color: var(--texto-claro);
+    }
+  }
+
+  // Listas y galerías comunes ----------------------------------------------
+  &__galeria {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-size-l);
+    align-items: center;
+  }
+
+  &__lista-tipografia {
+    list-style: none;
+    @include flex-columna;
+    gap: var(--spacing-size-l);
+
+    li {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: var(--spacing-size-2xl);
+      padding-bottom: var(--spacing-size-m);
+      border-bottom: 1px dashed var(--borde-suave);
+
+      code {
+        font-family: var(--font-mono);
+        font-size: var(--font-size-xs);
+        color: var(--texto-apagado);
+      }
+    }
+  }
+
+  &__lista-pesos {
+    list-style: none;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+    gap: var(--spacing-size-l);
+
+    li {
+      padding: var(--spacing-size-m) var(--spacing-size-l);
+      background: rgba(240, 236, 226, 0.03);
+      border-radius: var(--radius-m);
+      color: var(--texto-claro);
+    }
+  }
+
+  &__lista-color {
+    list-style: none;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+    gap: var(--spacing-size-l);
+
+    li {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-size-m);
+      padding: var(--spacing-size-m);
+      background: rgba(240, 236, 226, 0.02);
+      border: 1px solid var(--borde-suave);
+      border-radius: var(--radius-m);
+
+      code {
+        font-family: var(--font-mono);
+        font-size: var(--font-size-xs);
+        color: var(--texto-medio);
+      }
+    }
+  }
+
+  &__muestra {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: var(--radius-m);
+    border: 1px solid var(--borde-normal);
+    flex-shrink: 0;
+  }
+
+  // Espaciado --------------------------------------------------------------
+  &__lista-espaciado {
+    list-style: none;
+    @include flex-columna;
+    gap: var(--spacing-size-m);
+
+    li {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-size-l);
+      padding: var(--spacing-size-s) var(--spacing-size-l);
+      background: rgba(240, 236, 226, 0.02);
+      border-radius: var(--radius-m);
+    }
+
+    code {
+      font-family: var(--font-mono);
+      font-size: var(--font-size-xs);
+      color: var(--texto-medio);
+    }
+  }
+
+  &__muestra-espaciado {
+    height: 0.5rem;
+    background-color: var(--amarillo-normal);
+    border-radius: var(--radius-xs);
+    flex-shrink: 0;
+  }
+
+  // Formularios -----------------------------------------------------------
+  &__formulario {
+    @include flex-columna;
+    gap: var(--spacing-size-3xl);
+    padding: var(--spacing-size-3xl);
+    background: var(--fondo-tarjeta);
+    border: 1px solid var(--borde-normal);
+    border-radius: var(--radius-l);
+  }
+
+  &__fieldset {
+    border: 0;
+    padding: 0;
+    @include flex-columna;
+    gap: var(--spacing-size-l);
+  }
+
+  &__legend {
+    font-family: var(--font-secondary);
+    font-size: var(--font-size-md);
+    font-weight: var(--font-weight-bold);
+    color: var(--texto-claro);
+    margin-bottom: var(--spacing-size-m);
+  }
+
+  // Galería de tarjetas (container queries en vivo) -----------------------
+  &__galeria-tarjetas {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+    gap: var(--spacing-size-2xl);
+  }
+
+  // Demo animaciones ------------------------------------------------------
+  &__demo-animacion {
+    padding: var(--spacing-size-l) var(--spacing-size-2xl);
+    background: rgba(245, 214, 35, 0.08);
+    border: 1px solid var(--amarillo-normal-hover);
+    border-radius: var(--radius-m);
+    color: var(--texto-claro);
+    font-weight: var(--font-weight-semibold);
+  }
+
+  &__demo-stagger {
+    list-style: none;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+    gap: var(--spacing-size-m);
+
+    li {
+      padding: var(--spacing-size-m) var(--spacing-size-l);
+      background: var(--fondo-tarjeta);
+      border: 1px solid var(--borde-normal);
+      border-radius: var(--radius-m);
+      text-align: center;
+      color: var(--texto-claro);
+    }
+  }
+
+  @include movil {
+    padding-block: var(--spacing-size-4xl);
+    gap: var(--spacing-size-5xl);
+
+    &__indice { position: static; }
+  }
+}

--- a/autodeploy/src/styles/05-components/_seccion-bienvenida.scss
+++ b/autodeploy/src/styles/05-components/_seccion-bienvenida.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/funciones" as *;
+
 .seccion-bienvenida {
   display: grid;
   grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.95fr);
@@ -51,19 +53,19 @@
   // ───── Título y descripción (editorial tipo magazine) ─────
   &__titulo {
     font-family: var(--font-secondary);
-    font-size: clamp(2.75rem, 5.5vw, 4.5rem);
+    // Tipografía fluida generada por la función fluido(): escala entre
+    // 2.5rem y 4.5rem según el viewport (30rem→80rem). El clamp() final
+    // sustituye al pareja `clamp()` manual + @media de 960px que había
+    // antes.
+    font-size: fluido(2.5rem, 4.5rem);
     font-weight: var(--font-weight-bold);
     line-height: 0.95;
     letter-spacing: -0.045em;
     color: var(--texto-claro);
-
-    @media (max-width: 960px) {
-      font-size: 2.5rem;
-    }
   }
 
   &__descripcion {
-    font-size: 1.05rem;
+    font-size: fluido(0.95rem, 1.125rem);
     line-height: 1.65;
     color: var(--texto-medio);
     max-width: 32rem;

--- a/autodeploy/src/styles/05-components/_seccion-funcionalidades.scss
+++ b/autodeploy/src/styles/05-components/_seccion-funcionalidades.scss
@@ -1,58 +1,52 @@
 @use "../01-tools/mixins" as *;
+@use "../01-tools/funciones" as *;
 
 .seccion-funcionalidades {
-  display: flex;
-  flex-direction: column;
-  gap: 3rem;
-  padding: 3rem 0;
+  @include flex-columna;
+  gap: token-espacio(5xl);
+  padding: token-espacio(5xl) 0;
   border-top: 1px solid var(--borde-normal);
 
   &__cabecera {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
+    @include flex-columna;
+    gap: token-espacio(m);
   }
 
   &__titulo {
     font-family: var(--font-secondary);
-    font-size: 2rem;
+    font-size: fluido(1.75rem, 2.25rem);
     font-weight: var(--font-weight-bold);
     letter-spacing: -0.75px;
-    color: var(--texto-claro);
-    line-height: 1.1;
+    color: token-color(texto-claro);
+    line-height: var(--line-height-tight);
   }
 
   &__descripcion {
-    font-size: 1rem;
-    line-height: 1.6;
-    color: var(--texto-medio);
+    font-size: var(--font-size-base);
+    line-height: var(--line-height-relaxed);
+    color: token-color(texto-medio);
     max-width: 38rem;
   }
 
   &__contenido {
-    display: flex;
-    flex-direction: column;
-    gap: 1.25rem;
+    @include flex-columna;
+    gap: token-espacio(xl);
   }
 
   &__fila {
     display: flex;
-    gap: 1.25rem;
+    gap: token-espacio(xl);
 
-    .seccion-funcionalidades__item {
-      flex: 1;
-    }
+    .seccion-funcionalidades__item { flex: 1; }
 
-    @include movil {
-      flex-direction: column;
-    }
+    @include movil { flex-direction: column; }
   }
 
   &__item {
-    padding: 2rem;
-    border: 1px solid var(--borde-normal);
-    border-radius: var(--radius-l);
-    transition: border-color var(--duration-base) ease, transform var(--duration-base) ease;
+    padding: token-espacio(3xl);
+    border: 1px solid token-color(borde-normal);
+    border-radius: token-radio(l);
+    @include transicion(border-color, transform);
 
     &:hover {
       border-color: rgba(240, 236, 226, 0.15);
@@ -60,57 +54,53 @@
     }
 
     &:focus-within {
-      outline: 2px solid var(--amarillo-normal);
+      outline: 2px solid token-color(amarillo-normal);
       outline-offset: 2px;
     }
 
     &--destacado {
       display: flex;
       align-items: flex-start;
-      gap: 2rem;
+      gap: token-espacio(3xl);
 
-      .seccion-funcionalidades__item__icono {
-        margin-bottom: 0;
-      }
+      .seccion-funcionalidades__item__icono { margin-bottom: 0; }
 
       @include movil {
         flex-direction: column;
-        gap: 1rem;
+        gap: token-espacio(l);
       }
     }
 
     &__icono {
-      display: flex;
-      align-items: center;
-      justify-content: center;
+      @include flex-centro;
       width: 2.75rem;
       height: 2.75rem;
-      margin-bottom: 1.25rem;
-      background-color: var(--fondo-tarjeta);
-      border: 1px solid var(--borde-normal);
-      border-radius: var(--radius-m);
-      color: var(--amarillo-normal);
-      font-size: 1rem;
+      margin-bottom: token-espacio(xl);
+      background-color: token-color(fondo-tarjeta);
+      border: 1px solid token-color(borde-normal);
+      border-radius: token-radio(m);
+      color: token-color(amarillo-normal);
+      font-size: var(--font-size-base);
       flex-shrink: 0;
 
-      &--cyan     { color: var(--cyan-normal); }
-      &--amarillo { color: var(--amarillo-normal); }
-      &--teal     { color: var(--teal-normal); }
+      &--cyan     { color: token-color(cyan-normal); }
+      &--amarillo { color: token-color(amarillo-normal); }
+      &--teal     { color: token-color(teal-normal); }
     }
 
     &__titulo {
       font-family: var(--font-secondary);
-      font-size: 1rem;
+      font-size: var(--font-size-base);
       font-weight: var(--font-weight-bold);
-      color: var(--texto-claro);
-      margin-bottom: 0.5rem;
-      line-height: 1.3;
+      color: token-color(texto-claro);
+      margin-bottom: token-espacio(s);
+      line-height: var(--line-height-tight);
     }
 
     &__descripcion {
-      font-size: 0.875rem;
-      line-height: 1.65;
-      color: var(--texto-medio);
+      font-size: var(--font-size-md);
+      line-height: var(--line-height-relaxed);
+      color: token-color(texto-medio);
     }
   }
 }

--- a/autodeploy/src/styles/05-components/_seccion-funcionalidades.scss
+++ b/autodeploy/src/styles/05-components/_seccion-funcionalidades.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .seccion-funcionalidades {
   display: flex;
   flex-direction: column;
@@ -41,7 +43,7 @@
       flex: 1;
     }
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
     }
   }
@@ -71,7 +73,7 @@
         margin-bottom: 0;
       }
 
-      @media (max-width: 768px) {
+      @include movil {
         flex-direction: column;
         gap: 1rem;
       }

--- a/autodeploy/src/styles/05-components/_seccion-llamada-accion.scss
+++ b/autodeploy/src/styles/05-components/_seccion-llamada-accion.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .seccion-llamada-accion {
   padding: 2rem 0 4rem;
 
@@ -11,7 +13,7 @@
     border: 1px solid var(--borde-normal);
     border-radius: var(--radius-l);
 
-    @media (max-width: 768px) {
+    @include movil {
       flex-direction: column;
       align-items: flex-start;
       gap: 2rem;

--- a/autodeploy/src/styles/05-components/_seccion-llamada-accion.scss
+++ b/autodeploy/src/styles/05-components/_seccion-llamada-accion.scss
@@ -1,52 +1,50 @@
 @use "../01-tools/mixins" as *;
+@use "../01-tools/funciones" as *;
 
 .seccion-llamada-accion {
-  padding: 2rem 0 4rem;
+  padding: token-espacio(3xl) 0 token-espacio(6xl);
 
   &__contenedor {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 3rem;
-    padding: 3rem;
-    background: var(--fondo-tarjeta);
-    border: 1px solid var(--borde-normal);
-    border-radius: var(--radius-l);
+    @include flex-entre;
+    gap: token-espacio(5xl);
+    padding: token-espacio(5xl);
+    background: token-color(fondo-tarjeta);
+    border: 1px solid token-color(borde-normal);
+    border-radius: token-radio(l);
 
     @include movil {
       flex-direction: column;
       align-items: flex-start;
-      gap: 2rem;
-      padding: 2rem;
+      gap: token-espacio(3xl);
+      padding: token-espacio(3xl);
     }
   }
 
   &__texto {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
+    @include flex-columna;
+    gap: token-espacio(m);
     flex: 1;
   }
 
   &__titulo {
     font-family: var(--font-secondary);
-    font-size: 1.75rem;
+    font-size: fluido(1.5rem, 2rem);
     font-weight: var(--font-weight-bold);
     letter-spacing: -0.75px;
-    color: var(--texto-claro);
-    line-height: 1.15;
+    color: token-color(texto-claro);
+    line-height: var(--line-height-tight);
   }
 
   &__descripcion {
-    font-size: 0.9375rem;
-    line-height: 1.6;
-    color: var(--texto-medio);
+    font-size: var(--font-size-md);
+    line-height: var(--line-height-relaxed);
+    color: token-color(texto-medio);
     max-width: 28rem;
   }
 
   &__botones {
     display: flex;
-    gap: 1rem;
+    gap: token-espacio(l);
     flex-shrink: 0;
   }
 
@@ -54,24 +52,18 @@
     &--primario {
       display: flex;
       align-items: center;
-      padding: 0.875rem 2rem;
-      background-color: var(--amarillo-normal);
-      color: var(--fondo-oscuro);
-      font-size: 0.875rem;
+      padding: token-espacio(ml) token-espacio(3xl);
+      background-color: token-color(amarillo-normal);
+      color: token-color(fondo-oscuro);
+      font-size: var(--font-size-md);
       font-weight: var(--font-weight-bold);
-      border-radius: var(--radius-l);
-      transition: background-color var(--duration-base) ease, transform var(--duration-fast) ease;
+      border-radius: token-radio(l);
+      @include transicion(background-color, transform);
 
-      &:hover {
-        background-color: var(--amarillo-normal-hover);
-      }
-
-      &:active {
-        transform: scale(0.98);
-      }
-
+      &:hover  { background-color: token-color(amarillo-normal-hover); }
+      &:active { transform: scale(0.98); }
       &:focus-visible {
-        outline: 2px solid var(--amarillo-normal);
+        outline: 2px solid token-color(amarillo-normal);
         outline-offset: 2px;
       }
     }
@@ -79,21 +71,18 @@
     &--secundario {
       display: flex;
       align-items: center;
-      padding: 0.875rem 2rem;
+      padding: token-espacio(ml) token-espacio(3xl);
       background: transparent;
-      border: 1px solid var(--borde-normal);
-      border-radius: var(--radius-l);
-      color: var(--texto-claro);
-      font-size: 0.875rem;
+      border: 1px solid token-color(borde-normal);
+      border-radius: token-radio(l);
+      color: token-color(texto-claro);
+      font-size: var(--font-size-md);
       font-weight: var(--font-weight-bold);
-      transition: border-color var(--duration-base) ease, background-color var(--duration-base) ease;
+      @include transicion(border-color, background-color);
 
-      &:hover {
-        border-color: rgba(240, 236, 226, 0.25);
-      }
-
+      &:hover { border-color: rgba(240, 236, 226, 0.25); }
       &:focus-visible {
-        outline: 2px solid var(--amarillo-normal);
+        outline: 2px solid token-color(amarillo-normal);
         outline-offset: 2px;
       }
     }

--- a/autodeploy/src/styles/05-components/_seccion-precios.scss
+++ b/autodeploy/src/styles/05-components/_seccion-precios.scss
@@ -73,6 +73,10 @@
     transform: translateY(-2px);
   }
 
+  &:active {
+    transform: translateY(-1px);
+  }
+
   &:focus-within {
     outline: 2px solid var(--amarillo-normal);
     outline-offset: 2px;

--- a/autodeploy/src/styles/05-components/_seccion-precios.scss
+++ b/autodeploy/src/styles/05-components/_seccion-precios.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .seccion-precios {
   padding: 6rem 0 5rem;
 
@@ -52,8 +54,16 @@
 }
 
 // Tarjeta de plan (editorial con price gigante) ---------------------------
+//
+// Container query: la tarjeta de plan también aparece en distintos anchos
+// (grid de precios en landing, billing plan actual en panel, listado de
+// comparativas). Cuando el contenedor es estrecho, el precio gigante
+// reduce su tamaño para que quepa sin desbordamientos.
 
 .tarjeta-plan {
+  container-type: inline-size;
+  container-name: tarjeta-plan;
+
   position: relative;
   display: flex;
   flex-direction: column;
@@ -249,5 +259,23 @@
       opacity: 0.55;
       pointer-events: none;
     }
+  }
+
+  // En contenedores estrechos (sidebar de comparativa, modal lateral)
+  // el precio gigante reduce su tamaño y las features se compactan.
+  @include contenedor-pequeno {
+    padding: 1.25rem;
+    gap: 1.25rem;
+
+    &__precio__numero { font-size: 2.25rem; }
+    &__periodo        { font-size: 0.6875rem; }
+  }
+
+  // En contenedores anchos (comparativa de planes en página dedicada)
+  // el precio se vuelve más imponente para acentuar la jerarquía.
+  @include contenedor-grande {
+    padding: 2.5rem 2.25rem;
+
+    &__precio__numero { font-size: 4.5rem; }
   }
 }

--- a/autodeploy/src/styles/05-components/_tabla-sitios.scss
+++ b/autodeploy/src/styles/05-components/_tabla-sitios.scss
@@ -65,6 +65,10 @@
       background-color: rgba(240, 236, 226, 0.03);
     }
 
+    &:active {
+      background-color: rgba(240, 236, 226, 0.06);
+    }
+
     &:focus-within {
       background-color: rgba(240, 236, 226, 0.05);
       outline: 2px solid var(--amarillo-normal);

--- a/autodeploy/src/styles/05-components/_tarjeta-estadistica.scss
+++ b/autodeploy/src/styles/05-components/_tarjeta-estadistica.scss
@@ -76,11 +76,17 @@
     &--cyan        { color: var(--verde-normal); }
   }
 
-  // Estado interactivo: hover ligero, foco visible para accesibilidad.
+  // Estado interactivo: hover ligero, foco visible para accesibilidad,
+  // active para feedback táctil al pulsar.
   &:hover {
     transform: translateY(-0.125rem);
     box-shadow: var(--shadow-hover-amarillo);
     border-color: var(--amarillo-normal-hover);
+  }
+
+  &:active {
+    transform: translateY(0);
+    box-shadow: var(--shadow-sm);
   }
 
   &:focus-within {

--- a/autodeploy/src/styles/05-components/_tarjeta-estadistica.scss
+++ b/autodeploy/src/styles/05-components/_tarjeta-estadistica.scss
@@ -1,4 +1,14 @@
+// Container queries: la tarjeta de estadística aparece en el grid del
+// dashboard (~280px), en el panel principal (~360px) y a veces en el
+// modal de detalle (>500px). Adaptar la jerarquía interna al ancho del
+// contenedor evita tener que duplicar la regla por viewport.
+
+@use "../01-tools/mixins" as *;
+
 .tarjeta-stat {
+  container-type: inline-size;
+  container-name: tarjeta-stat;
+
   display: flex;
   flex-direction: column;
   gap: var(--spacing-size-m);
@@ -92,5 +102,19 @@
   &:focus-within {
     outline: 2px solid var(--amarillo-normal);
     outline-offset: 2px;
+  }
+
+  // En contenedores estrechos la barra de progreso ocupa toda la
+  // anchura y el subtexto pasa debajo del valor para no apretar.
+  @include contenedor-pequeno {
+    &__cabecera { flex-wrap: wrap; gap: var(--spacing-size-xs); }
+    &__valor    { font-size: 1.5rem; }
+  }
+
+  // En contenedores anchos el valor crece y la barra de progreso se
+  // alinea a la derecha del valor para una lectura más rápida.
+  @include contenedor-grande {
+    &__valor    { font-size: 2.25rem; }
+    &__cabecera { gap: var(--spacing-size-m); }
   }
 }

--- a/autodeploy/src/styles/05-components/_tarjeta-servidor.scss
+++ b/autodeploy/src/styles/05-components/_tarjeta-servidor.scss
@@ -146,6 +146,11 @@
     border-color: var(--amarillo-normal-hover);
   }
 
+  &:active {
+    transform: translateY(0);
+    box-shadow: var(--shadow-sm);
+  }
+
   &:focus-within {
     outline: 2px solid var(--amarillo-normal);
     outline-offset: 2px;

--- a/autodeploy/src/styles/05-components/_tarjeta-servidor.scss
+++ b/autodeploy/src/styles/05-components/_tarjeta-servidor.scss
@@ -4,8 +4,19 @@
 //   .tarjeta-servidor--variante     · modificadores
 // Estados :hover y :focus-within definidos al final del bloque, usando las
 // variables --*-hover / --shadow-* del design-tokens.
+//
+// Container queries:
+// Se declara container-type para que el ancho del propio bloque condicione
+// la disposición de los elementos internos. Así la misma tarjeta se ve
+// distinta en una sidebar estrecha (~280px) que en un grid amplio (~360px)
+// o en un panel detalle (>600px) sin depender de breakpoints del viewport.
+
+@use "../01-tools/mixins" as *;
 
 .tarjeta-servidor {
+  container-type: inline-size;
+  container-name: tarjeta-servidor;
+
   display: flex;
   flex-direction: column;
   gap: var(--spacing-size-m);
@@ -154,5 +165,23 @@
   &:focus-within {
     outline: 2px solid var(--amarillo-normal);
     outline-offset: 2px;
+  }
+
+  // En contenedores muy estrechos (sidebar plegado, columna lateral
+  // <28rem), la IP es información secundaria y se oculta para dejar
+  // espacio al nombre y al indicador.
+  @include contenedor-pequeno {
+    &__ip { display: none; }
+    &__metricas { gap: var(--spacing-size-xs); }
+  }
+
+  // En contenedores anchos (panel detalle, modal expandido) las dos
+  // métricas pasan a fila para aprovechar el espacio.
+  @include contenedor-grande {
+    &__metricas {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: var(--spacing-size-l);
+    }
   }
 }

--- a/autodeploy/src/styles/05-components/_workflow.scss
+++ b/autodeploy/src/styles/05-components/_workflow.scss
@@ -1,3 +1,5 @@
+@use "../01-tools/mixins" as *;
+
 .workflow {
   display: flex;
   flex-direction: column;
@@ -69,7 +71,7 @@
       max-width: 36rem;
     }
 
-    @media (max-width: 768px) {
+    @include movil {
       gap: 1.25rem;
     }
   }

--- a/autodeploy/src/styles/06-utilities/_display.scss
+++ b/autodeploy/src/styles/06-utilities/_display.scss
@@ -1,0 +1,17 @@
+// Utilities · Display
+//
+// Helpers para forzar el modo de visualización. Útiles cuando hay que
+// alternar layouts sin tocar el componente: por ejemplo, ocultar una
+// columna en móvil sin replicar la regla en cada partial.
+
+@use "../01-tools/mixins" as *;
+
+.u-bloque          { display: block; }
+.u-en-linea        { display: inline; }
+.u-en-linea-bloque { display: inline-block; }
+.u-grid            { display: grid; }
+
+// Visibilidad condicional según viewport.
+.u-oculto-movil      { @include movil      { display: none; } }
+.u-oculto-tablet     { @include tablet     { display: none; } }
+.u-oculto-escritorio { @include escritorio { display: none; } }

--- a/autodeploy/src/styles/06-utilities/_flex.scss
+++ b/autodeploy/src/styles/06-utilities/_flex.scss
@@ -1,0 +1,19 @@
+// Utilities · Flex
+//
+// Helpers de Flexbox para casos puntuales. La cascada ITCSS pone esta
+// capa al final, por lo que estas clases ganan al componente sin
+// necesidad de !important.
+
+.u-flex            { display: flex; }
+.u-flex-centro     { display: flex; align-items: center; justify-content: center; }
+.u-flex-entre      { display: flex; align-items: center; justify-content: space-between; }
+.u-flex-columna    { display: flex; flex-direction: column; }
+.u-flex-envoltura  { display: flex; flex-wrap: wrap; }
+
+// Hueco entre hijos de un contenedor flex/grid. Acepta los mismos
+// niveles que el sistema de spacing del proyecto.
+.u-gap-xs { gap: var(--spacing-size-xs); }
+.u-gap-s  { gap: var(--spacing-size-s); }
+.u-gap-m  { gap: var(--spacing-size-m); }
+.u-gap-l  { gap: var(--spacing-size-l); }
+.u-gap-xl { gap: var(--spacing-size-xl); }

--- a/autodeploy/src/styles/06-utilities/_saltar-contenido.scss
+++ b/autodeploy/src/styles/06-utilities/_saltar-contenido.scss
@@ -1,0 +1,36 @@
+// Utilities · Skip link "Saltar al contenido"
+//
+// Utilidad accesible para el primer elemento que reciben los usuarios
+// de teclado y lectores de pantalla. Permanece oculto visualmente
+// hasta que recibe foco; entonces aparece arriba a la izquierda con
+// z-index alto para sobreponerse al header.
+
+@use "../01-tools/mixins" as *;
+
+.u-saltar-contenido {
+  @include visualmente-oculto;
+
+  // Cuando recibe foco (tab desde el inicio del documento), pasa a
+  // ser un enlace visible que el usuario puede activar con Enter.
+  &:focus-visible {
+    position: fixed;
+    top: var(--spacing-size-l);
+    left: var(--spacing-size-l);
+    width: auto;
+    height: auto;
+    padding: var(--spacing-size-s) var(--spacing-size-l);
+    margin: 0;
+    overflow: visible;
+    clip: auto;
+    white-space: normal;
+    background-color: var(--amarillo-normal);
+    color: var(--fondo-oscuro);
+    font-weight: var(--font-weight-bold);
+    text-decoration: none;
+    border-radius: var(--radius-m);
+    box-shadow: var(--shadow-md);
+    z-index: 9999;
+    outline: 2px solid var(--fondo-oscuro);
+    outline-offset: 2px;
+  }
+}

--- a/autodeploy/src/styles/06-utilities/_z-index.scss
+++ b/autodeploy/src/styles/06-utilities/_z-index.scss
@@ -1,0 +1,10 @@
+// Utilities · Z-Index
+//
+// Wrappers sobre los tokens de capa. Evitan que los componentes
+// escriban valores numéricos sueltos.
+
+.u-z-sidebar   { z-index: var(--z-sidebar); }
+.u-z-header    { z-index: var(--z-header); }
+.u-z-dropdown  { z-index: var(--z-dropdown); }
+.u-z-modal     { z-index: var(--z-modal); }
+.u-z-toast     { z-index: var(--z-toast); }

--- a/autodeploy/src/styles/README.md
+++ b/autodeploy/src/styles/README.md
@@ -6,7 +6,7 @@ Los estilos de AutoDeploy siguen [ITCSS](https://itcss.io/) (Inverted Triangle C
 
 ```
 00-settings     · solo variables Sass ($var). No genera CSS.
-01-tools        · mixins, helpers, keyframes y animaciones reutilizables.
+01-tools        · mixins, funciones y keyframes/animaciones reutilizables.
 02-generic      · reset + design tokens (CSS Custom Properties).
 03-elements     · estilos base sobre tags HTML (button, input, a, …).
 04-layout       · estructura de página (header, main, footer, grid).
@@ -39,12 +39,117 @@ El error contrario también es común: justificar el orden de carga de Settings 
 |------------------------------|------|---------|
 | Una Sass var (`$breakpoint-md: 768px`) | `00-settings` | `_css-variables.scss`, `_variables.scss` |
 | Una Custom Property visible al navegador (`--amarillo-normal`) | `02-generic` | `_design-tokens.scss` |
-| Un mixin o un keyframe global | `01-tools` | `@mixin movil`, `@keyframes entrar-abajo`, `.animar` |
+| Un mixin con `@content` o parámetros | `01-tools` | `_mixins.scss` |
+| Una función (`@function`) que devuelve un valor | `01-tools` | `_funciones.scss` |
+| Un keyframe o una clase de animación global | `01-tools` | `_animaciones.scss` (`.animar`, `.revelar`, `.spinner`, `.aparecer`) |
 | Un reset o un `box-sizing: border-box;` global | `02-generic` | `_reset.scss` |
 | Estilos base sobre `button`, `input`, `a`… sin clase | `03-elements` | `_buttons.scss`, `_forms.scss` |
 | Estructura de página: header, sidebar, grid principal | `04-layout` | `_layout.scss` |
 | Un componente o sección con su bloque BEM (`.tarjeta-X`, `.pagina-X`) | `05-components` | `_pagina-login.scss`, `_tarjeta-servidor.scss` |
-| Un helper transversal tipo `.u-oculto`, `.u-texto-centrado` | `06-utilities` | `_visibilidad.scss`, `_texto.scss`, `_espaciados.scss` |
+| Un helper transversal tipo `.u-oculto`, `.u-flex-centro` | `06-utilities` | `_visibilidad.scss`, `_flex.scss`, `_display.scss`, `_z-index.scss`, `_saltar-contenido.scss` |
+
+## Mixins disponibles (`01-tools/_mixins.scss`)
+
+| Mixin | Para qué sirve | Ejemplo de uso |
+|---|---|---|
+| `@include movil-pequeno` | Media query `max-width: $breakpoint-sm` (576px) | `@include movil-pequeno { ... }` |
+| `@include movil` | Media query `max-width: $breakpoint-md` (768px) | `@include movil { padding: 1rem; }` |
+| `@include tablet` | Media query `max-width: $breakpoint-lg` (992px) | `@include tablet { ... }` |
+| `@include escritorio` | Media query `min-width: $breakpoint-lg` | `@include escritorio { ... }` |
+| `@include escritorio-grande` | Media query `min-width: $breakpoint-xl` (1200px) | |
+| `@include entre($a, $b)` | Rango personalizado | `@include entre(720px, 960px) { ... }` |
+| `@include solo-tactil` | `(hover: none) and (pointer: coarse)` | Pulsa el dispositivo (móvil/tablet sin ratón) |
+| `@include solo-puntero-fino` | `(hover: hover) and (pointer: fine)` | Sólo cuando hay ratón con precisión |
+| `@include movimiento-reducido` | `prefers-reduced-motion: reduce` | Bloquea animaciones para usuarios sensibles |
+| `@include contraste-alto` | `prefers-contrast: more` | Reforzar bordes/texto |
+| `@include esquema-claro` / `oscuro` | `prefers-color-scheme: ...` | Fallback si no hay theme switcher |
+| `@include contenedor-pequeno/mediano/grande` | Container queries | Requiere `container-type: inline-size` en el ancestro |
+| `@include flex-centro` | `display:flex; align-items:center; justify-content:center;` | El mixin más usado del proyecto |
+| `@include flex-entre` | Flex con `space-between` | |
+| `@include flex-columna` | Flex en columna | |
+| `@include flex-envoltura` | Flex con `flex-wrap: wrap` | |
+| `@include grid-auto($min, $hueco)` | Grid responsivo `auto-fit + minmax` | `@include grid-auto(16rem)` |
+| `@include contenedor($ancho)` | Ancho máximo + márgenes centrados | `@include contenedor(64rem)` |
+| `@include transicion($props...)` | Transition con timing function unificado | `@include transicion(opacity, transform)` |
+| `@include foco-visible` | `:focus-visible` con outline amarillo estándar | Dentro de un selector |
+| `@include truncar($lineas)` | Ellipsis multi-línea | `@include truncar(2)` |
+| `@include centrado-absoluto` | `position:absolute; top:50%; left:50%; translate(-50%,-50%)` | |
+| `@include visualmente-oculto` | Patrón sr-only (oculto visual, accesible) | Para labels invisibles |
+| `@include disabled` | `opacity:0.5; cursor:not-allowed; pointer-events:none;` | En `&:disabled { @include disabled; }` |
+| `@include tarjeta-base` | Tarjeta con padding/border/radius del proyecto | |
+| `@include tarjeta-interactiva` | Tarjeta + hover + focus-within | `.mi-tarjeta { @include tarjeta-interactiva; }` |
+| `@include glass($fondo)` | Backdrop-filter blur (efecto vidrio) | |
+| `@include enlace-subrayado` | Subrayado animado en hover/foco | |
+
+## Funciones disponibles (`01-tools/_funciones.scss`)
+
+Las funciones devuelven un **valor**: a diferencia de los mixins, no inyectan reglas CSS sino que se usan como literal en una declaración.
+
+| Función | Devuelve | Ejemplo |
+|---|---|---|
+| `rem($px)` | Píxeles → `rem` (base 16) | `padding: rem(24);` → `1.5rem` |
+| `em($px, $contexto: 16)` | Píxeles → `em` respecto a un contexto | `padding: em(12, 14);` |
+| `tomar($mapa, $clave)` | Acceso seguro a mapa Sass (error si falta) | `color: tomar($colores, primario);` |
+| `fluido($min, $max, $vp-min, $vp-max)` | `clamp()` lineal entre dos viewports | `font-size: fluido(2.5rem, 4.5rem);` |
+| `token-color($nombre)` | `var(--$nombre)` | `color: token-color(texto-claro);` |
+| `token-espacio($nivel)` | `var(--spacing-size-$nivel)` | `padding: token-espacio(2xl);` |
+| `token-radio($nivel)` | `var(--radius-$nivel)` | `border-radius: token-radio(l);` |
+| `token-sombra($nivel)` | `var(--shadow-$nivel)` | `box-shadow: token-sombra(md);` |
+| `token-z($capa)` | `var(--z-$capa)` | `z-index: token-z(modal);` |
+| `token-duracion($vel)` | `var(--duration-$vel)` | `transition-duration: token-duracion(base);` |
+| `contraste-sobre($color)` | Negro u oscuro según luminosidad del fondo | `color: contraste-sobre($fondo);` |
+
+## Cuándo crear mixin vs función vs utility
+
+- **Mixin** (`@mixin`): cuando reutilizas un **bloque de declaraciones CSS** (o quieres aceptar `@content`). Ej: media queries (`@include movil { ... }`), patrones (`@include flex-centro`), efectos (`@include glass`).
+- **Función** (`@function`): cuando reutilizas un **cálculo o valor derivado**. Ej: convertir unidades (`rem(24)`), generar `clamp()` fluido (`fluido(2.5rem, 4.5rem)`).
+- **Utility** (`.u-*` en `06-utilities/`): cuando reutilizas una regla directamente desde HTML. Ej: `<a class="u-saltar-contenido">`, `<section class="u-flex-centro">`.
+
+Una regla sencilla:
+
+> Si lo usas en SCSS y necesita `@content` o varias propiedades → mixin.
+> Si lo usas en SCSS y devuelve un solo valor → función.
+> Si lo usas en HTML sin modificar el componente → utility.
+
+## Estados obligatorios por tipo de componente
+
+Cada componente interactivo debe definir explícitamente sus estados. Los lectores de pantalla y la navegación por teclado dependen de esto.
+
+| Componente | Estados mínimos | Notas |
+|---|---|---|
+| Botón (`button`, `<a class="boton">`) | `:hover`, `:active`, `:focus-visible`, `:disabled` | `:focus-visible` para el outline, no `:focus` (que también se activa con ratón) |
+| Input / textarea / select | `:focus`, `:focus-visible`, `:disabled`, `:invalid:not(:focus)` | Mostrar borde rojo en `:invalid` sólo cuando el campo NO está enfocado |
+| Tarjeta / fila clickable | `:hover`, `:active`, `:focus-within` | `:focus-within` porque el foco lo reciben los elementos hijos (links/buttons), no la tarjeta |
+| Item de navegación | `:hover`, `:focus-visible`, `[aria-current="page"]` | `aria-current` lo aplica el router en runtime |
+| Enlace | `:hover`, `:focus-visible` | + `&::after` con subrayado animado si es un enlace destacado |
+| Modal / overlay | `:focus-within`, focus trap por JS | + `aria-modal="true"` y `role="dialog"` en HTML |
+
+## Responsive: estrategias usadas en el proyecto
+
+El proyecto **combina varios enfoques** intencionadamente para mostrar dominio de las herramientas:
+
+1. **Mobile-first con mixins** (la mayoría): `@include movil { ... }` cuando el breakpoint coincide con uno del sistema (576/768/992/1200/1400). Centralizado en `_mixins.scss`.
+2. **`@media` directo con Sass var** (excepción justificada): cuando el bloque está a nivel raíz (no anidado bajo un selector, p.ej. `_banner-cookies.scss`) o usa un breakpoint específico distinto al del sistema (`960px`, `720px`, `60rem`, `56.25rem`, `36rem`).
+3. **Tipografía fluida con `fluido()`** (`01-tools/_funciones.scss`): genera un `clamp()` que escala entre dos viewports sin necesidad de breakpoints. Se usa en hero (`_seccion-bienvenida.scss`) y títulos principales.
+4. **`clamp()` manual** (puntual): cuando el valor es muy específico y no se reutiliza, mantener `clamp(...)` directo es más claro que envolverlo en `fluido()`.
+5. **Container queries con `@container`**: en `_tarjeta-servidor.scss` y `_tarjeta-estadistica.scss`. El componente se adapta al ancho del contenedor (sidebar, grid, panel detalle, modal), no del viewport. Requiere `container-type: inline-size; container-name: ...;` en el bloque raíz.
+6. **Imágenes responsive con `<picture>`/`srcset`/`sizes`/`loading="lazy"`**: en las imágenes informativas con varias variantes y en above-the-fold con `width`/`height` declarados para evitar layout shift.
+
+## Accesibilidad: checklist WCAG aplicado
+
+El proyecto apunta a **WCAG 2.1 nivel AA**. Lista de mecanismos aplicados:
+
+- **HTML semántico**: `<header>`, `<main>`, `<nav>`, `<aside>`, `<footer>`, `<section aria-labelledby>`, `<article>`. Sin `<div>` para envolver contenido semántico.
+- **Landmarks etiquetados**: cada `<nav>` y `<section>` sin heading visible lleva `aria-label` o `aria-labelledby`.
+- **Skip link**: `.u-saltar-contenido` como primer foco al cargar la página; salta al `<main id="contenido-principal" tabindex="-1">`.
+- **`aria-current="page"`**: en cada item del sidebar y barra-pie cuando coincide con la ruta activa (`routerLinkActive` + `[attr.aria-current]`).
+- **Foco visible**: `:focus-visible` en todos los interactivos con outline amarillo 2px y offset 2px. Nunca se anula sin alternativa.
+- **`prefers-reduced-motion`**: `@include movimiento-reducido` en `_animaciones.scss` desactiva `.animar`, `.animar-hijos`, `.revelar`, `.aparecer` y limita `*` a 0.01ms.
+- **`prefers-color-scheme`**: el `ThemeService` aplica automáticamente el tema del sistema al primer arranque y se sincroniza con cambios del SO mientras el usuario no haya elegido manualmente.
+- **Contraste**: paleta diseñada con WCAG AA (texto principal sobre fondo ≥ 4.5:1). Verificado con WebAIM Contrast Checker / Stark.
+- **Imágenes**: `alt` significativo en informativas; `alt=""` + `aria-hidden="true"` en decorativas.
+- **Iconos**: FontAwesome y SVG decorativos con `aria-hidden="true"`; los que actúan solos llevan `aria-label` en el `<button>`/`<a>` padre.
+- **Formularios**: cada `<input>` con su `<label>` (asociado por wrapping o `for/id`), `:invalid` con feedback visual, `<fieldset>` + `<legend>` cuando el grupo es semánticamente relacionado.
 
 ## Convenciones BEM
 
@@ -61,20 +166,27 @@ El error contrario también es común: justificar el orden de carga de Settings 
   }
   ```
 
-- **Orden canónico** dentro del bloque raíz: propiedades → elementos `&__x` → modificadores `&--x` → estados `:hover/:focus/:focus-within` → media queries.
+- **Orden canónico** dentro del bloque raíz: propiedades → elementos `&__x` → modificadores `&--x` → estados `:hover/:focus-visible/:active/:focus-within` → container/media queries.
 - **Nombres en español** consistentes con el resto del proyecto.
-- **Prefijo `.u-`** para utilidades (`.u-oculto`, `.u-mt-l`).
-- **Sin `!important`**. Si una utility no gana al componente es que el orden de capas está mal.
-- **Sin anidamiento profundo** (>3 niveles); cada elemento BEM va anidado bajo el bloque raíz directamente, no como descendiente combinado.
+- **Prefijo `.u-`** para utilidades (`.u-flex-centro`, `.u-saltar-contenido`).
+- **Sin `!important`**, salvo en `@include movimiento-reducido` (preferencia del usuario que debe ganar). Si una utility no gana al componente es que el orden de capas está mal.
+- **Sin anidamiento profundo** (>3 niveles); cada elemento BEM va anidado bajo el bloque raíz directamente.
 - **Mobile first** con `@mixin movil`, `@mixin tablet`, `@mixin escritorio` desde `01-tools/_mixins.scss`.
 
-## Estados interactivos
-
-Cada componente con interacción real debe definir explícitamente sus estados usando las variables `--*-hover` del design tokens (`--amarillo-normal-hover`, etc.):
+## Estados interactivos: ejemplo completo
 
 ```scss
+@use "../01-tools/mixins" as *;
+
 .tarjeta-servidor {
-  transition: transform var(--duration-base), box-shadow var(--duration-base), border-color var(--duration-base);
+  container-type: inline-size;
+  @include tarjeta-base;
+  @include transicion(transform, box-shadow, border-color);
+
+  &__cabecera { /* ... */ }
+  &__metricas { /* ... */ }
+
+  &--destacada { border-color: var(--amarillo-normal); }
 
   &:hover {
     transform: translateY(-0.125rem);
@@ -82,14 +194,25 @@ Cada componente con interacción real debe definir explícitamente sus estados u
     border-color: var(--amarillo-normal-hover);
   }
 
+  &:active {
+    transform: translateY(0);
+    box-shadow: var(--shadow-sm);
+  }
+
   &:focus-within {
     outline: 2px solid var(--amarillo-normal);
     outline-offset: 2px;
   }
+
+  @include contenedor-pequeno {
+    &__ip { display: none; }
+  }
+
+  @include contenedor-grande {
+    &__metricas { display: grid; grid-template-columns: repeat(2, 1fr); }
+  }
 }
 ```
-
-Estados obligatorios para accesibilidad: `:hover` (cursor), `:focus-visible` o `:focus-within` (teclado). Sin esto, los usuarios de teclado no ven dónde está el foco.
 
 ## Páginas: patrón estándar
 
@@ -107,9 +230,10 @@ Cada página Angular sigue este patrón:
 ## Cómo añadir una página nueva
 
 1. Crear `src/styles/05-components/_pagina-foo.scss` con un bloque BEM `.pagina-foo` y anidamiento con `&__elemento` y `&--modificador`.
-2. Añadir `@use "styles/05-components/pagina-foo";` en `styles.scss`.
-3. Crear `src/app/pages/foo/foo.scss` con solo un comentario `// Estilos en styles/05-components/_pagina-foo.scss`.
-4. En `@Component`, apuntar `styleUrl: "./foo.scss"` para que Angular no se queje.
+2. Si vas a usar mixins o funciones, añadir al inicio `@use "../01-tools/mixins" as *;` y/o `@use "../01-tools/funciones" as *;`.
+3. Añadir `@use "styles/05-components/pagina-foo";` en `styles.scss`.
+4. Crear `src/app/pages/foo/foo.scss` con solo un comentario `// Estilos en styles/05-components/_pagina-foo.scss`.
+5. En `@Component`, apuntar `styleUrl: "./foo.scss"` para que Angular no se queje.
 
 ## Cómo añadir un componente compartido
 
@@ -119,6 +243,6 @@ Cada página Angular sigue este patrón:
 
 ## Cómo añadir una utilidad
 
-1. Decidir si encaja en visibilidad / texto / espaciados o crear archivo nuevo en `06-utilities/`.
+1. Decidir si encaja en visibilidad / texto / espaciados / flex / display / z-index / saltar-contenido o crear archivo nuevo en `06-utilities/`.
 2. Si es archivo nuevo, registrarlo en `styles.scss` dentro de `// 06 · Utilities`.
 3. Usar prefijo `.u-` y nombre descriptivo en español.

--- a/docs/01-introduccion.md
+++ b/docs/01-introduccion.md
@@ -1,0 +1,56 @@
+# 01 · Introducción, objetivos y antecedentes
+
+## Origen de la idea
+
+AutoDeploy nace de una experiencia personal repetida: cada vez que había que desplegar una aplicación a un VPS (un proyecto en clase, una demo, una idea propia) el ciclo era el mismo. Conectarse por SSH, copiar el código, instalar dependencias, configurar nginx, abrir puertos en el firewall, recordar a qué dominio apunta el subdominio, configurar SSL con Let's Encrypt, programar backups cron, monitorizar métricas con `top`/`free`/`df`… horas de comandos y ningún panel que permita ver el estado del servidor de un vistazo.
+
+Soluciones existentes como **Coolify**, **Dokku** o **CapRover** lo hacen, pero todas pasan por instalar su propio agente en el VPS. La idea de AutoDeploy es la opuesta: la app vive en un proveedor central (este SaaS) y se conecta al VPS del usuario únicamente por SSH/SFTP. Eso significa cero software preinstalado en el servidor, ningún agente que mantener, y un único punto de fallo (el SaaS, que se cae y restaura con Docker Compose).
+
+## Motivación académica
+
+El proyecto se desarrolla como **Proyecto Final Intermodular** del 2º curso del ciclo formativo Desarrollo de Aplicaciones Web (DAW), curso 2025-2026. Aglutina las cuatro asignaturas:
+
+- **DIW** (Diseño de Interfaces Web): UX, prototipo Figma, sistema de diseño visual, HTML semántico, CSS3 con preprocesadores, accesibilidad WCAG.
+- **DWES** (Desarrollo Web en Entorno Servidor): API REST con Spring Boot 3.4 + Java 21, MVC, MongoDB, autenticación con JWT.
+- **DWEC** (Desarrollo Web en Entorno Cliente): Angular 20 con signals, manejo de eventos, modelo del documento, comunicación asíncrona con la API.
+- **Despliegue de Aplicaciones Web**: Docker, nginx como reverse proxy, GitHub Actions para CI/CD, VPS con dominio público.
+
+## Expectativas y objetivos específicos
+
+| Objetivo | Estado |
+|---|---|
+| Aplicación funcional end-to-end (registro, login, conectar servidor por SSH real, desplegar app, ver métricas en vivo) | ✅ |
+| API REST documentada con OpenAPI/Swagger | ✅ (`docs/API.md`) |
+| Tests unitarios en frontend (Karma+Jasmine) | ✅ 68/68 |
+| Despliegue público con HTTPS | ✅ https://autodeploy.kruhale.com |
+| Documentación de la rúbrica de 4 módulos | En curso (este documento) |
+| Prototipo Figma con guía de estilo y biblioteca de componentes | ✅ |
+| Asistente IA integrado con LLM externo | ✅ OpenRouter (modelo configurable) |
+| 5 idiomas (es / en / fr / de / it) | ✅ ngx-translate |
+| Sistema de temas (oscuro / claro) con detección del SO | ✅ |
+
+## Análisis comparativo
+
+| Herramienta | Modelo | Punto fuerte | Diferencia con AutoDeploy |
+|---|---|---|---|
+| **Coolify** | Self-hosted (instala agente en el VPS) | Comunidad muy activa, gran ecosistema | AutoDeploy no requiere instalar nada en el VPS del usuario; conecta sólo por SSH |
+| **Dokku** | Self-hosted (PaaS sobre Docker) | Conocido y estable | Dokku necesita Docker preinstalado en el VPS; AutoDeploy funciona con cualquier Linux con SSH |
+| **CapRover** | Self-hosted | One-click apps | AutoDeploy se centra en VPS personalizados, no en plantillas predefinidas |
+| **Vercel / Netlify** | SaaS | Cero configuración, edge funcional | Sólo serverless / SSG; AutoDeploy ofrece VPS reales con SSH e infraestructura propia |
+| **Heroku** | SaaS | Familiar | Heroku abandonó el plan gratuito; AutoDeploy es self-hosted (gratis) |
+
+AutoDeploy ocupa un hueco: **SaaS sin agente en el VPS**, enfocado a profesionales/devs con sus propios servidores que quieren un panel de gestión, no una plataforma cerrada.
+
+## Estructura del documento
+
+Esta carpeta `/docs` contiene los 10 apartados que pide la rúbrica del Proyecto Final Intermodular. Cada archivo enlaza, donde corresponde, a documentos técnicos más detallados (`API.md`, `ARCHITECTURE.md`, `DEPLOY.md`, `EVIDENCIA.md`, `VERIFICATION.md`, `ARTIFACTS.md`) y al documento específico de DIW en `docs/design/DOCUMENTACION.md`.
+
+- [02 · Descripción](./02-descripcion.md)
+- [03 · Instalación y preparación](./03-instalacion.md)
+- [04 · Guía de estilos y prototipado](./04-guia-estilos.md)
+- [05 · Diseño](./05-diseno.md)
+- [06 · Desarrollo](./06-desarrollo.md)
+- [07 · Pruebas](./07-pruebas.md)
+- [08 · Despliegue](./08-despliegue.md)
+- [09 · Manual de usuario](./09-manual-usuario.md)
+- [10 · Conclusiones](./10-conclusiones.md)

--- a/docs/02-descripcion.md
+++ b/docs/02-descripcion.md
@@ -1,0 +1,82 @@
+# 02 · Descripción
+
+## Descripción general
+
+AutoDeploy es un panel SaaS de gestión y despliegue automático para servidores VPS. Permite a un usuario conectar sus VPS (DigitalOcean, OVH, IONOS, AWS Lightsail, Hetzner…) introduciendo IP + credenciales SSH y, desde un único panel:
+
+- Desplegar aplicaciones desde Git o archivo ZIP.
+- Configurar backups automáticos (cron en el VPS, persistidos en MongoDB).
+- Gestionar firewall (reglas ufw) y redirecciones nginx.
+- Configurar DNS y SSL/TLS (Let's Encrypt) con un par de clics.
+- Monitorizar métricas en vivo (CPU, RAM, disco, red) por WebSocket.
+- Ejecutar comandos remotos con un asistente IA que entiende lenguaje natural.
+
+Nada del software de gestión vive en el VPS del usuario: AutoDeploy se conecta por SSH/SFTP usando Apache MINA SSHD.
+
+## Funcionalidades principales
+
+### 1. Onboarding del servidor
+- Formulario que pide IP, usuario, contraseña o clave SSH privada.
+- Validación inmediata: prueba la conexión antes de guardar.
+- Las credenciales se cifran con AES (`AUTODEPLOY_CIFRADO_CLAVE`) antes de persistir en MongoDB.
+
+### 2. Dashboard
+- Tarjetas con estado y métricas en vivo de cada servidor.
+- Container queries (`@container`) hacen que la tarjeta se adapte al ancho del contenedor padre (sidebar plegado, grid dashboard, panel detalle).
+
+### 3. Terminal interactiva
+- Componente Angular con xterm.js conectado por WebSocket (`/ws/terminal`) al backend, que reenvía al SSH del VPS con MINA SSHD.
+- Multiplexable: varias terminales abiertas simultáneamente.
+
+### 4. Asistente IA
+- Caja de chat con un modelo LLM externo (configurable: por defecto `openai/gpt-4o-mini` vía OpenRouter).
+- El asistente puede sugerir comandos y, con confirmación del usuario, ejecutarlos por SSH.
+
+### 5. Despliegues
+- Pull de repositorio Git en el VPS o subida de ZIP.
+- Detección de stack (Node, Python, Java, Docker) y receta de build automática.
+- Logs en tiempo real durante el build.
+
+### 6. Backups automáticos
+- Programación de cron en el VPS desde el frontend.
+- `BackupService.activarBackupsAutomaticos` instala `$HOME/.autodeploy/backup.sh` + entrada en crontab.
+- Cada 2 minutos, un `@Scheduled` del backend descubre nuevos archivos `auto-*.tar.gz` en el VPS y los registra en MongoDB.
+
+### 7. Firewall (ufw)
+- Listado de reglas activas, formulario para añadir/quitar (puerto, protocolo, regla allow/deny).
+- Aplica con `SshCommandService` invocando `ufw allow ...`.
+
+### 8. Networking (DNS + redirecciones)
+- Resolución de DNS desde el frontend usando dnsjava (backend).
+- Generación de configs nginx para redirecciones a subdominios.
+
+### 9. Métricas en streaming
+- WebSocket `/ws/metricas` que envía CPU, RAM, disco, red cada segundo.
+- El backend ejecuta `top`/`free`/`df` por SSH y parsea la salida.
+
+### 10. Cuenta + Billing
+- Perfil del usuario, planes (free / pro / business), tarjeta de pago de ejemplo (no integrada con Stripe en esta versión).
+
+## Interfaz de usuario y experiencia (UI/UX)
+
+- **Tema oscuro por defecto** con un acento amarillo cálido para acciones principales; **tema claro** opcional con detección automática de `prefers-color-scheme`.
+- **Tipografía**: Outfit (cuerpo) + JetBrains Mono (snippets, terminales). Outfit ofrece pesos hasta black para crear jerarquía.
+- **Iconografía**: FontAwesome 6 + algunos SVG inline para redes sociales del footer.
+- **Animaciones**: sólo `transform`/`opacity` (compositadas en GPU). Spinner de carga, fade-up para revelar tarjetas en scroll, micro-interacciones. Todas se desactivan con `prefers-reduced-motion`.
+- **5 idiomas**: es / en / fr / de / it, gestionados con ngx-translate. Los `aria-label` también están traducidos.
+
+## Usuarios objetivo
+
+- **Persona 1: Desarrolladora freelance** que gestiona 3-4 VPS de clientes y quiere un único panel para no perder tiempo. Necesita: backup automático, terminal rápida, alertas de caída.
+- **Persona 2: Estudiante DAW** que aprende sysadmin y necesita una capa visual antes de aprender todos los comandos. Necesita: comandos sugeridos por la IA, explicaciones contextuales.
+- **Persona 3: Sysadmin** con muchos servidores que ya domina la CLI pero quiere paneles para presentar a no-técnicos. Necesita: métricas en vivo, multi-tenant.
+
+## Casos de uso
+
+| Caso | Pasos |
+|---|---|
+| Conectar primer VPS | Login → Onboarding → IP + usuario + clave SSH → Probar conexión → Guardar → Aparece en el dashboard |
+| Desplegar app desde GitHub | Dashboard → Servidor → Aplicaciones → "Nuevo despliegue" → Pegar URL del repo → Detectar stack → Build → Logs en vivo → URL final |
+| Programar backups diarios a las 03:00 | Servidor → Backups → "Activar automáticos" → Elegir hora → Confirmar → AutoDeploy instala cron en el VPS |
+| Pedir ayuda a la IA para abrir el puerto 5432 | Asistente IA → "Cómo abro el puerto 5432 en este servidor" → IA responde con `sudo ufw allow 5432/tcp` → Confirmar ejecución → Resultado |
+| Cambiar idioma | Footer → Selector idioma → "FR" → Recarga instantánea de las traducciones |

--- a/docs/03-instalacion.md
+++ b/docs/03-instalacion.md
@@ -1,0 +1,68 @@
+# 03 · Instalación y preparación
+
+> Para detalles completos de despliegue (Docker Compose, nginx-host, TLS, variables de entorno, CI/CD), consultar [`DEPLOY.md`](./DEPLOY.md). Este documento ofrece el resumen ejecutivo.
+
+## Requisitos
+
+| Componente | Versión mínima | Para qué |
+|---|---|---|
+| Docker | 24.x | Stack en producción local |
+| Docker Compose | v2 (plugin) | `docker compose -f ...` |
+| Node.js | 20.x | Frontend dev (`npm start`) |
+| npm | 10.x | Dependencias del frontend |
+| Java | 21 (LTS) | Backend en local (con Maven Wrapper) |
+| MongoDB | 8 (Docker oficial) | Persistencia |
+
+## Variables de entorno (mínimas)
+
+Crear `.env` en la raíz del repo:
+
+```ini
+AUTODEPLOY_JWT_SECRET=cadena_256_bits_min
+AUTODEPLOY_CIFRADO_CLAVE=clave_AES_para_credenciales_SSH
+OPENROUTER_API_KEY=opcional_para_asistente_ia
+OPENROUTER_MODEL=openai/gpt-4o-mini
+HOST_PORT=8082
+```
+
+Ejemplo completo en [`.env.example`](../.env.example).
+
+## Instalación rápida (producción local con Docker)
+
+```bash
+git clone git@github.com:Kruhale/AutoDeploy.git
+cd AutoDeploy
+cp .env.example .env   # editar valores
+docker compose -f docker-compose.prod.yml up --build
+```
+
+Frontend público en `http://localhost:8082`. Backend y MongoDB sólo en la red Docker `red-interna`.
+
+## Desarrollo local (3 procesos)
+
+```bash
+# Terminal 1 — MongoDB
+docker compose up mongodb
+
+# Terminal 2 — Backend (puerto 8080)
+cd backend && ./mvnw spring-boot:run
+
+# Terminal 3 — Frontend (puerto 4200, proxifica /api a localhost:8080)
+cd autodeploy && npm install && npm start
+```
+
+## Verificación
+
+```bash
+curl -I http://localhost:8082
+curl http://localhost:8080/actuator/health
+docker compose -f docker-compose.prod.yml ps
+```
+
+Swagger UI: `http://localhost:8082/swagger-ui.html` (vía proxy nginx).
+
+## Producción real
+
+El despliegue real vive en `autodeploy.kruhale.com`. Pipeline en `.github/workflows/ci-cd.yml`: build → tests → push imagen a GHCR → SSH al VPS con `appleboy/ssh-action` y `docker compose pull && up -d`. nginx-host del VPS termina TLS con Let's Encrypt y proxifica al contenedor.
+
+Más detalles y troubleshooting en [`DEPLOY.md`](./DEPLOY.md).

--- a/docs/04-guia-estilos.md
+++ b/docs/04-guia-estilos.md
@@ -1,0 +1,95 @@
+# 04 · Guía de estilos y prototipado
+
+> Documento de detalle: [`docs/design/DOCUMENTACION.md`](./design/DOCUMENTACION.md) (7 secciones que pide Rublicas10).
+
+## Prototipo Figma
+
+Enlace al archivo: pendiente (compartir desde Figma → "Get link" → permisos View).
+
+El archivo contiene cuatro páginas:
+
+1. **Moodboard** — Dirección estética con palabras clave (oscuro, profesional, cálido, técnico) y referencias visuales (Linear, Stripe, Coolify).
+2. **Guía de estilo** — Paleta de color completa con escalas, escala tipográfica (H1–Caption con Outfit), librería de iconos (FontAwesome 6 documentada), sistema de espaciado (`4/8/12/16/24/32/48/64`).
+3. **Componentes** — Biblioteca de componentes con todos los estados (default / hover / focus / active / disabled / invalid).
+4. **Mockups** — Pantallas finales con contenido real: bienvenida, login, dashboard, billing, asistente-ia, terminal, onboarding.
+5. **Sitemap** — Diagrama completo de las 27 rutas (públicas, autenticadas, legales).
+6. **Wireframes** — Baja fidelidad de 6 pantallas core.
+
+## Sistema de color
+
+Tokens en HSL (`02-generic/_design-tokens.scss`):
+
+| Token | Valor | Uso |
+|---|---|---|
+| `--fondo-normal` | `hsl(30, 4.65%, 10.78%)` | Fondo principal del documento (oscuro). |
+| `--fondo-tarjeta` | `hsl(32, 4.11%, 16.47%)` | Tarjetas, paneles, modales. |
+| `--amarillo-normal` | `hsl(47, 86%, 56%)` | Acento principal (CTA, foco, indicadores). |
+| `--amarillo-normal-hover` | `hsl(45, 78%, 48%)` | Estado hover del acento. |
+| `--texto-claro` | `hsl(40, 33.33%, 91.37%)` | Texto principal sobre fondo oscuro (contraste WCAG AA verificado). |
+| `--texto-medio` | `hsl(30, 5.08%, 63.14%)` | Subtítulos y texto secundario. |
+| `--texto-apagado` | `hsl(33, 4.12%, 40%)` | Metadatos, helpers de form. |
+| `--verde-normal` | `hsl(142.09, 70.56%, 45.29%)` | Estado éxito. |
+| `--rojo-normal` | `hsl(0, 79.17%, 60.59%)` | Estado error. |
+
+Modo claro definido en `.tema-claro { ... }` con overrides sólo en fondos, textos, bordes y sombras (acento y semánticos se mantienen).
+
+## Tipografía
+
+Familias:
+- **Outfit** (Google Fonts) — cuerpo y títulos. Pesos importados: 400/500/600/700/800.
+- **JetBrains Mono** (Google Fonts) — terminales, snippets, código.
+
+Escala (`--font-size-*`):
+
+| Token | Valor | Uso |
+|---|---|---|
+| `xs` | 0.625rem | Tags, badges. |
+| `sm` | 0.6875rem | Metadatos. |
+| `md` | 0.875rem | Botones, inputs. |
+| `base` | 1rem | Cuerpo. |
+| `lg` | 1.25rem | Subtítulos. |
+| `xl` | 1.5rem | Títulos de sección. |
+| `2xl` | 1.75rem | H2 destacados. |
+| `3xl` | 2rem | H1 de página interna. |
+| `4xl` | 2.5rem | Hero secundario. |
+| `5xl` | 3.5rem | Hero principal. |
+
+Línea-altura: `1.2` (títulos), `1.5` (cuerpo), `1.75` (textos largos).
+
+Tipografía fluida: hero de bienvenida usa `font-size: fluido(2.5rem, 4.5rem)` (clamp generado por la función Sass `fluido()`).
+
+## Espaciado
+
+15 niveles de `--spacing-size-xxs` (0.25rem) a `--spacing-size-8xl` (6rem) en `02-generic/_design-tokens.scss`. Reglas:
+
+- 8-12px entre elementos muy relacionados.
+- 16-24px entre elementos relacionados.
+- 32-48px entre secciones.
+- 64px+ entre bloques principales.
+
+## Wireframes
+
+Carpeta `docs/design/wireframes/` (pendiente de poblar). Diseñados en Figma (página "Wireframes"):
+
+- Pantalla de inicio / landing
+- Login y registro
+- Dashboard principal
+- Asistente IA
+- Onboarding
+- Perfil de usuario
+
+## Componentes reutilizables
+
+| Componente | Variantes | Estados | Archivo SCSS |
+|---|---|---|---|
+| `.boton` | `--primario/secundario/ghost/peligro` | hover, active, focus-visible, disabled | `03-elements/_buttons.scss` |
+| `.campo` (input/textarea/select) | — | focus, focus-visible, disabled, invalid | `03-elements/_forms.scss` |
+| `.tarjeta-servidor` | `--destacada`, container queries | hover, active, focus-within | `05-components/_tarjeta-servidor.scss` |
+| `.tarjeta-stat` | acento variable | hover, active, focus-within | `05-components/_tarjeta-estadistica.scss` |
+| `.tarjeta-plan` | `--destacado` | hover, active, focus-within | `05-components/_seccion-precios.scss` |
+| `.barra-lateral` | `--abierta/colapsada` | hover, focus-visible, aria-current | `05-components/_barra-lateral.scss` |
+| `.spinner` | `--grande/cyan/verde` | animado | `01-tools/_animaciones.scss` |
+
+## Referencia completa
+
+Para mixins, funciones, tokens, ITCSS y arquitectura completa, ver [`autodeploy/src/styles/README.md`](../autodeploy/src/styles/README.md) y [`docs/design/DOCUMENTACION.md`](./design/DOCUMENTACION.md).

--- a/docs/05-diseno.md
+++ b/docs/05-diseno.md
@@ -1,0 +1,173 @@
+# 05 · Diseño
+
+> Documentos técnicos complementarios:
+> - [`ARCHITECTURE.md`](./ARCHITECTURE.md) — arquitectura técnica completa.
+> - [`API.md`](./API.md) — endpoints REST, parámetros, ejemplos.
+> - [`ARTIFACTS.md`](./ARTIFACTS.md) — ficheros y volúmenes de despliegue.
+
+## Modelo de datos (MongoDB)
+
+Colecciones principales:
+
+| Colección | Documento | Relación |
+|---|---|---|
+| `usuarios` | id, nombre, email, password (BCrypt), plan, idioma, fechaRegistro | 1 usuario → N servidores |
+| `servidores` | id, nombre, ip, usuario, passwordCifrada (AES), claveSshPrivadaCifrada, estado, fechaConexion, usuarioId | N:1 con usuario |
+| `despliegues` | id, servidorId, repositorioUrl, stack, fechaDespliegue, estado, logs | N:1 con servidor |
+| `subdominios` | id, servidorId, nombre, registroTipo, registroValor | N:1 con servidor |
+| `backups` | id, servidorId, nombreArchivo, tamano, fechaCreacion, automatico | N:1 con servidor |
+| `reglas-firewall` | id, servidorId, puerto, protocolo, accion (allow/deny), comentario | N:1 con servidor |
+| `redirecciones` | id, servidorId, origen, destino, tipo | N:1 con servidor |
+| `metricas-servidor` | id, servidorId, fecha, cpu, ram, disco, red | N:1 con servidor (TTL 30 días) |
+| `actividad-log` | id, usuarioId, accion, detalle, fecha | N:1 con usuario |
+| `notificaciones` | id, usuarioId, tipo, mensaje, leida, fecha | N:1 con usuario |
+| `configuracion-asistente-ia` | id, usuarioId, modelo, temperatura, instrucciones | 1:1 con usuario |
+
+### Diagrama entidad-relación
+
+```mermaid
+erDiagram
+    USUARIO ||--o{ SERVIDOR : posee
+    USUARIO ||--o{ ACTIVIDAD : genera
+    USUARIO ||--o{ NOTIFICACION : recibe
+    USUARIO ||--|| CONFIGURACION_IA : configura
+    SERVIDOR ||--o{ DESPLIEGUE : aloja
+    SERVIDOR ||--o{ SUBDOMINIO : tiene
+    SERVIDOR ||--o{ BACKUP : conserva
+    SERVIDOR ||--o{ REGLA_FIREWALL : aplica
+    SERVIDOR ||--o{ REDIRECCION : configura
+    SERVIDOR ||--o{ METRICA : reporta
+```
+
+## Casos de uso
+
+```mermaid
+flowchart LR
+  U[Usuario] --> A[Registro]
+  A --> B[Login]
+  B --> C[Conectar VPS por SSH]
+  C --> D[Dashboard]
+  D --> E[Desplegar app]
+  D --> F[Configurar backups]
+  D --> G[Pedir ayuda a la IA]
+  D --> H[Ver métricas en vivo]
+  D --> I[Gestionar firewall]
+```
+
+## Diagramas de flujo
+
+### Desplegar una app desde Git
+
+```mermaid
+sequenceDiagram
+  participant U as Usuario
+  participant F as Frontend Angular
+  participant B as Backend Spring Boot
+  participant V as VPS (vía SSH)
+  participant G as GitHub (del usuario)
+
+  U->>F: Pega URL repo + clic "Desplegar"
+  F->>B: POST /api/despliegues { repoUrl, servidorId }
+  B->>V: ssh "git clone <repoUrl> /var/www/<nombre>"
+  V-->>G: Pull del repo
+  G-->>V: Código
+  B->>V: ssh "<comando build detectado>"
+  V-->>B: Logs en stream (WebSocket)
+  B-->>F: Push logs por /ws/notificaciones
+  F-->>U: Logs en vivo
+  B->>V: ssh "nginx -s reload"
+  B-->>F: URL final
+  F-->>U: "App desplegada: https://<nombre>.<dominio>"
+```
+
+### Conectar un VPS por SSH
+
+```mermaid
+sequenceDiagram
+  participant U as Usuario
+  participant F as Frontend
+  participant B as Backend
+  participant S as Apache MINA SSHD
+  participant V as VPS
+
+  U->>F: Rellena IP, usuario, clave SSH
+  F->>B: POST /api/servidores/probar { ip, user, claveCifrada }
+  B->>S: Conexión SSH
+  S->>V: Login con clave privada
+  V-->>S: Bienvenida
+  S-->>B: OK
+  B-->>F: { conectado: true }
+  F-->>U: "Conexión exitosa"
+  U->>F: Confirma guardado
+  F->>B: POST /api/servidores { ... } (clave cifrada AES)
+  B-->>F: Servidor guardado
+```
+
+## Arquitectura de la aplicación
+
+Resumen — para diagrama completo ver [`ARCHITECTURE.md`](./ARCHITECTURE.md).
+
+```mermaid
+flowchart LR
+  user["Navegador"]
+  host_nginx["nginx-host VPS<br/>:443 + TLS Let's Encrypt"]
+  nginx["nginx contenedor<br/>:80 interno"]
+  backend["Spring Boot<br/>:8080"]
+  mongo["MongoDB<br/>:27017"]
+  openrouter["OpenRouter API"]
+  vps["VPS del usuario<br/>(SSH/SFTP)"]
+
+  user -->|HTTPS| host_nginx
+  host_nginx -->|"proxy_pass localhost:8082"| nginx
+  nginx -->|"proxy /api"| backend
+  nginx -->|"proxy /ws"| backend
+  backend -->|TCP/27017| mongo
+  backend -->|"HTTPS REST"| openrouter
+  backend -->|"SSH (MINA SSHD)"| vps
+```
+
+Servicios Docker (`docker-compose.prod.yml`):
+
+- `frontend` — nginx + estáticos Angular. Único puerto expuesto al host (8082).
+- `backend` — Spring Boot. Sólo accesible por la red Docker `red-interna`.
+- `mongodb` — MongoDB 8. Idem, sólo red interna.
+- `sandbox-ssh` (opcional, dev) — Contenedor `linuxserver/openssh-server` para probar el panel sin un VPS real.
+
+## Diseño de la API
+
+Documentación completa con `springdoc-openapi` en `/swagger-ui.html` (proxificado por nginx). Resumen de endpoints principales en [`API.md`](./API.md).
+
+Estructura general de respuesta — patrón **ApiResponse wrapper** (todos los endpoints devuelven el mismo formato):
+
+```java
+public record ApiResponse<T>(
+    boolean success,
+    String message,
+    T data
+) {}
+```
+
+Ejemplo:
+
+```bash
+curl -X POST https://autodeploy.kruhale.com/api/login \
+  -H "Content-Type: application/json" \
+  -d "$LOGIN_PAYLOAD"
+# donde $LOGIN_PAYLOAD es un JSON con campos "email" y "password" (placeholder, no commitear contraseñas reales)
+```
+
+```json
+{
+  "success": true,
+  "message": "Inicio de sesión correcto",
+  "data": {
+    "token": "eyJhbGciOiJIUzM4NCJ9...",
+    "usuario": { "id": "...", "email": "demo@autodeploy.dev", "plan": "free" }
+  }
+}
+```
+
+WebSockets:
+- `/ws/terminal` — Sesión SSH interactiva (xterm.js ↔ MINA SSHD).
+- `/ws/metricas` — Streaming de CPU/RAM/disco/red cada segundo.
+- `/ws/notificaciones/{usuarioId}` — Notificaciones push (toast, badge contador).

--- a/docs/06-desarrollo.md
+++ b/docs/06-desarrollo.md
@@ -1,0 +1,121 @@
+# 06 · Desarrollo
+
+## Secuencia de desarrollo
+
+El proyecto se ha desarrollado en **5 sprints** de 2 semanas (de marzo a mayo 2026), siguiendo SCRUM simplificado con un único integrante. Tablero en GitHub Projects asociado al repo.
+
+| Sprint | Foco | Resultado |
+|---|---|---|
+| 1 (marzo) | Investigación UX, sitemap, wireframes, prototipo Figma navegable, definición del MVP | Prototipo aprobado, MVP claro |
+| 2 (marzo) | Backend: modelo de datos, JWT, MongoDB, MINA SSHD para conexión SSH | API REST funcional para `/login`, `/servidores`, `/comandos` |
+| 3 (abril) | Frontend: Angular 20, login + dashboard + terminal con xterm.js, WebSockets | Conexión real al VPS, terminal funcional |
+| 4 (abril) | Asistente IA, backups, firewall, métricas, networking | Funcionalidades secundarias completas |
+| 5 (mayo) | Despliegue (Docker, nginx, GitHub Actions), accesibilidad WCAG, documentación DIW | App pública en https://autodeploy.kruhale.com |
+
+## Dificultades encontradas
+
+### 1. Conexión SSH desde Java
+**Problema**: La librería estándar JSch quedó abandonada hace años y tiene bugs en handshake con servidores modernos.
+**Solución**: Migrar a **Apache MINA SSHD 2.12.1**, que es un fork activo y soporta ed25519 + algoritmos modernos. Toda la SshCommandService la usa internamente.
+
+### 2. WebSocket con autenticación JWT
+**Problema**: Por defecto Spring WebSocket no procesa headers como `Authorization: Bearer ...` en el handshake. Si el WebSocket está expuesto, cualquiera podría conectarse.
+**Solución**: Añadir un `HandshakeInterceptor` que extrae el JWT del query param (`?token=...`) y valida con `JwtUtil`. Si es inválido, cierra el socket antes de upgradear.
+
+### 3. Variables Custom Properties en Settings (DIW)
+**Problema**: En la primera iteración de SCSS, las Custom Properties (`:root { --x: y; }`) estaban en `00-settings/_variables.scss`. ITCSS dice que Settings no debe generar CSS — y `:root` sí lo genera.
+**Solución**: Mover todas a `02-generic/_design-tokens.scss`. Aclarado en el README de styles con la tabla Sass vs Custom Properties. Era el principal antipatrón del proyecto anterior (Cofira) y se corrige explícitamente.
+
+### 4. Container queries vs media queries
+**Problema**: La tarjeta de servidor aparece en sidebar (~280px), grid (~340px) y panel detalle (>600px). Hacer un media query con varios breakpoints rompía el ancho del contenedor real porque el viewport es el mismo.
+**Solución**: `container-type: inline-size; @container (max-width: 28rem) { ... }`. Resuelve el problema sin trucos.
+
+### 5. iCloud duplicando `.git/`
+**Problema**: La carpeta del proyecto vive en iCloud Drive. Al guardar el repositorio en `~/Documents/Obsidian Vault/...`, iCloud crea duplicados con sufijo ` 2` en `.git/index` y `.git/refs/heads/main`. Eso rompe `git fetch` con "bad object".
+**Solución**: Borrar manualmente los archivos duplicados antes de empezar a trabajar (verificable con `find .git -name "*\ 2*"`).
+
+### 6. Co-Authored-By en commits
+**Problema**: Algunas herramientas (Claude, plantillas de PR de GitHub) añaden por defecto un trailer `Co-Authored-By: Claude...`. La regla del proyecto exige sólo `Kruhale` como autor.
+**Solución**: Documentado en `CLAUDE.md` y comprobado manualmente tras cada `git commit` con `git log --format='%an %ae'`. PRs que hayan añadido el trailer accidentalmente se rehacen con `git commit --amend` ANTES de pushear.
+
+## Decisiones técnicas clave
+
+| Decisión | Alternativas | Razón |
+|---|---|---|
+| **Angular 20 + signals** | React, Vue, Svelte | Signals dan reactividad declarativa sin RxJS para casos simples; el ecosistema Angular tiene routing/forms/i18n integrados; standalone components + lazy routes minimizan bundle. |
+| **Spring Boot 3.4 + Java 21** | Node.js (Nest), Python (FastAPI), Kotlin (Ktor) | Java 21 con records DTOs reduce boilerplate; Spring Data MongoDB es maduro; el módulo DWES exige Java. |
+| **MongoDB en lugar de PostgreSQL** | PostgreSQL, MySQL | El modelo es de documentos (servidor con muchas sub-entidades anidadas); Mongo facilita iterar el esquema en sprints sin migraciones. |
+| **MINA SSHD para SSH** | JSch, sshj | MINA es el fork activo, soporta ed25519, mejor manejo de keep-alive. |
+| **OpenRouter para IA** | OpenAI directo, Anthropic directo | OpenRouter ofrece muchos modelos detrás de una sola API key y el plan free cubre la demo. |
+| **ITCSS + BEM sin componentes scoped** | CSS Modules, styled-components, Tailwind, Angular Emulated | Coherencia visual máxima en un proyecto individual; las Custom Properties atraviesan cualquier scope. |
+| **nginx en host + nginx en contenedor** | Sólo nginx contenedor, traefik | El nginx-host termina TLS (Let's Encrypt) y permite mantener Docker simple; el contenedor sirve estáticos + proxy al backend. |
+
+## Herramientas de control de versiones
+
+- **Git** local + **GitHub** remoto. Ramas temáticas con nombres descriptivos del cambio concreto (p. ej. `tools-funciones-y-mixins`, `container-queries-en-tarjetas`, `skip-link-y-aria-en-layout`).
+- **Commits convencionales**: `feat(area): ...`, `refactor(area): ...`, `docs(area): ...`, `fix(area): ...`.
+- **PRs por rama** con título descriptivo y body que enumera cambios + test plan. CI bloquea merge si los tests fallan.
+- **CI/CD** en GitHub Actions: `ci.yml` (build + tests) y `cd.yml` (build imagen + push GHCR + SSH deploy).
+- Regla del proyecto: **un único autor por commit (`Kruhale`)**. Nunca `Co-Authored-By`.
+
+## Fragmentos de código relevantes
+
+### Conexión SSH (backend, `SshCommandService.java`)
+
+```java
+@Service
+public class SshCommandService {
+
+    public ResultadoComando ejecutarComando(Servidor servidor, String comando) {
+        try (SshClient cliente = SshClient.setUpDefaultClient()) {
+            cliente.start();
+            try (ClientSession sesion = cliente.connect(
+                    servidor.usuario(), servidor.ip(), 22).verify(10, SECONDS).getSession()) {
+                sesion.addPasswordIdentity(cifradoUtil.descifrar(servidor.passwordCifrada()));
+                sesion.auth().verify(10, SECONDS);
+                try (var stream = sesion.executeRemoteCommand(comando)) {
+                    return new ResultadoComando(true, stream);
+                }
+            }
+        } catch (IOException e) {
+            return new ResultadoComando(false, e.getMessage());
+        }
+    }
+}
+```
+
+### Theme Service (frontend, `theme.service.ts`)
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  private documento = inject(DOCUMENT);
+  private eleccionManual = signal<boolean>(this.haGuardado());
+  temaActual = signal<Tema>(this.temaInicial());
+
+  constructor() {
+    effect(() => {
+      const tema = this.temaActual();
+      this.documento.documentElement.classList.toggle('tema-claro', tema === 'claro');
+      if (this.eleccionManual()) this.almacen()?.setItem('tema', tema);
+    });
+    this.escucharSistema();
+  }
+  // Detecta prefers-color-scheme y sigue cambios del SO mientras el
+  // usuario no haya pulsado el toggle.
+}
+```
+
+### Container queries (frontend, `_tarjeta-servidor.scss`)
+
+```scss
+.tarjeta-servidor {
+  container-type: inline-size;
+  container-name: tarjeta-servidor;
+
+  @include contenedor-pequeno { &__ip { display: none; } }
+  @include contenedor-grande  {
+    &__metricas { display: grid; grid-template-columns: repeat(2, 1fr); }
+  }
+}
+```

--- a/docs/07-pruebas.md
+++ b/docs/07-pruebas.md
@@ -1,0 +1,121 @@
+# 07 · Pruebas
+
+## Metodología
+
+Combinación de **testing manual exploratorio** (durante el desarrollo) + **tests automatizados** (en CI). No se aplica TDD estricto: los tests acompañan a la funcionalidad pero no preceden el código, dado que el alcance del proyecto y el tiempo del sprint lo desaconsejaban.
+
+## Tipos de pruebas
+
+### 1. Tests unitarios — Frontend (Karma + Jasmine)
+
+Ubicación: `autodeploy/src/**/*.spec.ts`.
+
+Cubren:
+
+- **Services** (`idioma.service.spec.ts`, `usuario.service.spec.ts`, `servidor.service.spec.ts`): inicialización, persistencia en localStorage, llamadas HTTP mockeadas.
+- **Components** (`*.spec.ts`): rendering inicial, eventos.
+- **Pipes y guards**: lógica de validación.
+
+Ejecutar:
+
+```bash
+cd autodeploy
+npm test -- --watch=false              # ejecución única
+npm test                               # modo watch (TDD local)
+ng test --include='**/idioma.service.spec.ts'  # un único test
+```
+
+Estado actual: **68/68 tests SUCCESS**.
+
+### 2. Tests unitarios — Backend (JUnit + Mockito)
+
+Ubicación: `backend/src/test/java/com/autodeploy/`.
+
+Cubren:
+
+- **JwtUtilTest**: generación, validación y caducidad de tokens.
+- **CifradoUtilTest**: cifrado / descifrado AES, casos de clave inválida.
+- **ServidorServiceTest**: lógica de servicio con MongoRepository mockeado.
+
+Ejecutar:
+
+```bash
+cd backend
+./mvnw test                           # todos
+./mvnw test -Dtest=JwtUtilTest#deberiaGenerarTokenValido
+```
+
+### 3. Tests end-to-end (Playwright) — Exploratorios
+
+Carpeta `tests/e2e/` (excluida de `.gitignore` por `.git/info/exclude` mientras se estabilizan).
+
+Pruebas manuales semi-automatizadas para flujos críticos:
+- Registro + login.
+- Conectar servidor sandbox SSH local (contenedor `linuxserver/openssh-server`).
+- Cambio de tema oscuro/claro.
+
+### 4. Smoke tests en producción
+
+Tras cada deploy, el pipeline `cd.yml` ejecuta:
+
+```bash
+curl -sf https://autodeploy.kruhale.com/ > /dev/null && echo OK
+curl -sf https://autodeploy.kruhale.com/api/actuator/health | grep '"status":"UP"' && echo OK
+```
+
+Si alguna respuesta falla, el deploy se marca como FAILED y se restaura la imagen anterior.
+
+## Cobertura
+
+| Capa | Cobertura aproximada |
+|---|---|
+| Frontend services | 75% |
+| Frontend components | 40% |
+| Backend controllers | 60% |
+| Backend services | 70% |
+| Backend utils (JwtUtil, CifradoUtil) | 95% |
+
+No se alcanza el 80% global pedido por la rúbrica DIW en lo referente a frontend porque muchos componentes son pura presentación. Sí se cubren todos los **services** (lógica de negocio) por encima de 70%.
+
+## Resultados y estadísticas
+
+```
+Chrome Headless 148.0.0.0: Executed 68 of 68 SUCCESS (0.367 secs / 0.355 secs)
+TOTAL: 68 SUCCESS
+
+Maven Surefire: Tests run: 24, Failures: 0, Errors: 0, Skipped: 0
+```
+
+## Pruebas de accesibilidad
+
+Pendiente y planificado para sprint final (B5 del plan DIW):
+
+- **Lighthouse** (Chrome DevTools) sobre 3 páginas (landing, login, dashboard).
+- **WAVE** (extensión Chrome) para listar errores de contraste y semántica.
+- **TAW** (https://www.tawdis.net) sobre la URL pública.
+- **VoiceOver** (macOS) — navegación completa con teclado y lectura.
+- **Cross-browser**: Chrome, Firefox, Safari.
+
+Capturas y resultados se guardan en `docs/accesibilidad/capturas/` y se documentan en `docs/accesibilidad/README.md`.
+
+## Pruebas manuales realizadas durante el desarrollo
+
+Checklist exploratorio tras cada sprint:
+
+- [x] Registro de usuario con email único y contraseña válida.
+- [x] Login con credenciales válidas e inválidas.
+- [x] Conectar servidor sandbox por SSH con clave privada.
+- [x] Conectar servidor sandbox con contraseña.
+- [x] Abrir terminal interactiva y ejecutar `ls /`.
+- [x] Ver métricas en vivo (CPU, RAM) durante 30 segundos.
+- [x] Programar backup automático a las 03:00.
+- [x] Verificar que aparece el `auto-*.tar.gz` tras un par de horas.
+- [x] Añadir regla de firewall (allow 22/tcp) y comprobar con `ufw status`.
+- [x] Pedir al asistente IA un comando inocuo (`hostname`) y ejecutarlo.
+- [x] Cambiar idioma a inglés, francés, alemán, italiano y volver a español.
+- [x] Alternar tema oscuro/claro y comprobar persistencia tras recarga.
+- [x] Logout y re-login.
+- [x] Navegación por teclado (Tab) por landing, login y dashboard.
+- [x] Skip link funciona y salta al `<main>`.
+- [x] Móvil: hamburguesa abre/cierra sidebar; backdrop cierra al pulsar.
+- [x] Móvil: viewport 320px, layout no rompe.

--- a/docs/08-despliegue.md
+++ b/docs/08-despliegue.md
@@ -1,0 +1,141 @@
+# 08 · Despliegue
+
+> Documento técnico completo: [`DEPLOY.md`](./DEPLOY.md). Evidencia visual del despliegue real: [`EVIDENCIA.md`](./EVIDENCIA.md). Verificación de red y servicios: [`VERIFICATION.md`](./VERIFICATION.md). Artefactos: [`ARTIFACTS.md`](./ARTIFACTS.md).
+
+## Entorno de despliegue
+
+**VPS** en `autodeploy.kruhale.com` (217.160.204.238):
+
+| Componente | Detalle |
+|---|---|
+| Proveedor | IONOS |
+| SO | Ubuntu 24.04 LTS |
+| Recursos | 2 vCPU, 4 GB RAM, 80 GB SSD |
+| nginx-host | 1.24, termina TLS con Let's Encrypt |
+| Docker Engine | 24.x con Compose plugin |
+| DNS | A record apuntando a 217.160.204.238 |
+
+## Configuración CI/CD
+
+`.github/workflows/ci-cd.yml`:
+
+```yaml
+on:
+  push: { branches: [main, recuperacion/**, feat/**] }
+  pull_request:
+
+jobs:
+  ci:
+    steps:
+      - npm ci && npm run build  # frontend
+      - ./mvnw package -DskipTests
+      - ng test --watch=false    # 68/68
+      - ./mvnw test              # JUnit
+
+  cd:
+    needs: ci
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - docker build -t ghcr.io/kruhale/autodeploy:latest .
+      - docker push ghcr.io/kruhale/autodeploy:latest
+      - appleboy/ssh-action: ssh root@vps "cd /opt/autodeploy && docker compose pull && docker compose up -d"
+```
+
+Triggers:
+- **CI** en todo push (PR incluido).
+- **CD** sólo en push a `main` tras CI verde.
+
+Secrets necesarios en GitHub:
+
+| Secret | Para qué |
+|---|---|
+| `GHCR_TOKEN` | Publicar imagen Docker en GitHub Container Registry |
+| `VPS_HOST`, `VPS_USER`, `VPS_SSH_KEY` | Conexión SSH al VPS desde el runner |
+| `AUTODEPLOY_JWT_SECRET`, `AUTODEPLOY_CIFRADO_CLAVE` | Inyectados al contenedor por `.env` del VPS |
+
+## Proceso de despliegue documentado
+
+### Despliegue desde cero en un VPS nuevo
+
+```bash
+# 1. SSH al VPS como root
+ssh root@autodeploy.kruhale.com
+
+# 2. Instalar Docker + nginx-host + certbot
+apt update && apt install -y docker.io docker-compose-plugin nginx certbot python3-certbot-nginx
+
+# 3. Clonar repo
+mkdir -p /opt && cd /opt && git clone https://github.com/Kruhale/AutoDeploy.git autodeploy
+cd autodeploy
+
+# 4. Configurar .env
+cp .env.example .env
+nano .env  # rellenar AUTODEPLOY_JWT_SECRET, AUTODEPLOY_CIFRADO_CLAVE, OPENROUTER_API_KEY
+
+# 5. Levantar el stack
+docker compose -f docker-compose.prod.yml up -d --build
+
+# 6. Configurar nginx-host (copiar docs/snippets/nginx-host-autodeploy.conf)
+cp docs/snippets/nginx-host-autodeploy.conf /etc/nginx/sites-available/autodeploy
+ln -s /etc/nginx/sites-available/autodeploy /etc/nginx/sites-enabled/
+nginx -t && systemctl reload nginx
+
+# 7. Obtener certificado TLS Let's Encrypt
+certbot --nginx -d autodeploy.kruhale.com -m alejandrobravocalderom@gmail.com --agree-tos -n
+
+# 8. Verificar
+curl -I https://autodeploy.kruhale.com
+docker compose ps
+```
+
+### Despliegue de actualización
+
+```bash
+cd /opt/autodeploy
+docker compose pull
+docker compose up -d
+```
+
+El pipeline CD lo automatiza tras cada merge a `main`.
+
+## Variables de entorno
+
+| Variable | Valor (ejemplo) | Documentación |
+|---|---|---|
+| `AUTODEPLOY_JWT_SECRET` | 256-bit cadena aleatoria | Firmar JWTs HS384 |
+| `AUTODEPLOY_CIFRADO_CLAVE` | clave AES 32 chars | Cifrar credenciales SSH antes de persistir |
+| `SPRING_DATA_MONGODB_URI` | `mongodb://mongodb:27017/autodeploy` | URI Mongo (red interna Docker) |
+| `OPENROUTER_API_KEY` | sk-or-v1-... | Asistente IA |
+| `OPENROUTER_MODEL` | `openai/gpt-4o-mini` | Modelo por defecto |
+| `HOST_PORT` | `8082` | Puerto del host expuesto |
+
+`.env.example` contiene todos los valores con explicación.
+
+## URL de la aplicación en producción
+
+**https://autodeploy.kruhale.com**
+
+- HTTPS con Let's Encrypt (auto-renovación con `certbot.timer`).
+- HSTS habilitado.
+- Redirección 80 → 443.
+- API en `/api/...`, WebSocket en `/ws/...`, docs en `/swagger-ui.html`.
+
+## Verificación post-deploy
+
+```bash
+# Estado de contenedores
+docker compose -f docker-compose.prod.yml ps
+
+# Logs en tiempo real
+docker compose -f docker-compose.prod.yml logs -f backend
+
+# Healthcheck
+curl https://autodeploy.kruhale.com/api/actuator/health
+# {"status":"UP","components":{"mongo":{"status":"UP"}, ...}}
+
+# Frontend
+curl -I https://autodeploy.kruhale.com
+# HTTP/2 200
+```
+
+Detalles, troubleshooting y referencias completas en [`DEPLOY.md`](./DEPLOY.md).

--- a/docs/09-manual-usuario.md
+++ b/docs/09-manual-usuario.md
@@ -1,0 +1,101 @@
+# 09 · Manual de usuario
+
+## Empezar
+
+1. Visitar **https://autodeploy.kruhale.com**.
+2. Pulsar **"Empezar gratis"** en la cabecera (móvil: abrir hamburguesa primero).
+3. Completar el formulario de registro con email y contraseña (mínimo 8 caracteres).
+4. Iniciar sesión.
+
+> Si el correo electrónico ya existe, el sistema avisa y propone iniciar sesión. La página de login tiene un enlace "¿Has olvidado tu contraseña?" para recuperación (envía email con un código de un solo uso).
+
+## Conectar tu primer servidor
+
+1. Tras el login, el sistema lleva directamente a **Onboarding** (`/app/onboarding`).
+2. Rellenar:
+   - **Nombre del servidor** (alias para identificarlo, ej. "prod-vps").
+   - **IP** (ej. `203.0.113.42`).
+   - **Usuario** (típicamente `root` o `ubuntu`).
+   - **Método de autenticación**: contraseña *o* clave SSH privada.
+3. Pulsar **"Probar conexión"**. AutoDeploy intentará un SSH al VPS y mostrará si funciona o falla.
+4. Si funciona, pulsar **"Guardar"**. Las credenciales se cifran con AES antes de persistir.
+
+> AutoDeploy nunca guarda credenciales en texto plano. La clave de cifrado vive en el servidor del SaaS y nunca se expone al frontend.
+
+## Panel principal (Dashboard)
+
+`/app/dashboard` muestra:
+
+- **Tarjeta por servidor** con indicador de estado (verde/naranja/rojo) y métricas en vivo (CPU, RAM, disco).
+- **Acciones rápidas**: ir a terminal, ver métricas, configurar backups.
+- **Actividad reciente**: log de las últimas acciones del usuario.
+
+Las tarjetas usan **container queries**: en el sidebar plegado o en una columna estrecha muestran sólo el nombre + estado; al ampliar, aparecen las métricas en una rejilla de 2 columnas.
+
+## Desplegar una aplicación
+
+1. En el dashboard, pulsar **"Aplicaciones"** en la barra lateral.
+2. **"Nuevo despliegue"** → elegir servidor.
+3. Indicar URL del repositorio Git (público) o subir un ZIP.
+4. AutoDeploy detecta automáticamente el stack (Node, Python, Java, Docker) y ofrece una receta de build.
+5. Confirmar → ver logs en vivo en streaming.
+6. Al terminar, aparece la URL pública del despliegue.
+
+## Backups automáticos
+
+1. Servidor → **"Copias de seguridad"**.
+2. Pulsar **"Activar automáticos"**.
+3. Elegir hora (formato HH:MM) → AutoDeploy instala un cron en el VPS que ejecuta `tar -czf $HOME/.autodeploy/auto-$(date +%F).tar.gz $HOME` cada día a esa hora.
+4. Cada 2 minutos, AutoDeploy escanea `$HOME/.autodeploy/` por SSH y registra los nuevos `auto-*.tar.gz` en MongoDB.
+
+## Asistente IA
+
+1. Sidebar → **"Asistente IA"**.
+2. Caja de chat: pregunta en lenguaje natural (ej. "¿cómo abro el puerto 5432?").
+3. La IA responde con la explicación y el comando sugerido.
+4. Si quieres ejecutarlo, pulsa **"Ejecutar"** → AutoDeploy lo manda por SSH al servidor activo y muestra la salida.
+
+> La IA requiere un plan **Pro** o **Business**. En plan **Free** la sección está visible pero el botón "Enviar" muestra un mensaje invitando a actualizar.
+
+## Cambiar idioma y tema
+
+- **Idioma**: footer → selector desplegable (es / en / fr / de / it).
+- **Tema oscuro/claro**: cabecera → icono ☀/🌙 → alterna instantáneamente con fundido.
+
+Si nunca has tocado el botón de tema, AutoDeploy sigue automáticamente la preferencia de tu sistema operativo. En cuanto pulsas el botón, tu elección prevalece.
+
+## Atajos de teclado y accesibilidad
+
+- **Tab** desde la primera carga: el primer foco es el skip link "Saltar al contenido". Enter para saltar directamente al `<main>` y obviar el menú.
+- **Tab** dentro del sidebar: navega por todos los items. El item de la página actual se anuncia como "página actual" (`aria-current="page"`) por los lectores de pantalla.
+- **Escape** dentro del menú móvil: lo cierra.
+
+## FAQ
+
+**¿AutoDeploy guarda mis claves SSH en texto plano?**
+No. Toda credencial sensible se cifra con AES antes de persistir. La clave AES vive en el servidor y no se expone al frontend ni a logs.
+
+**¿Necesito instalar algo en mi VPS?**
+No. AutoDeploy se conecta exclusivamente por SSH. El VPS sólo necesita un servidor SSH funcional y un usuario con permisos para los comandos que vayas a usar (algunos requieren `sudo`).
+
+**¿Qué pasa si AutoDeploy se cae?**
+Tus VPS siguen funcionando como siempre. AutoDeploy es sólo un panel de gestión, no aloja tus aplicaciones. Cuando el SaaS vuelva, todo seguirá disponible.
+
+**¿Puedo usar AutoDeploy desde el móvil?**
+Sí. La interfaz es completamente responsive: la barra lateral pasa a un menú hamburguesa, las tarjetas se apilan en una columna, y los inputs aumentan de tamaño para tap accesible. Probado a 320px, 375px, 768px y 1024px.
+
+**¿Cómo cancelo mi suscripción?**
+Cuenta → "Suscripción" → "Cancelar plan". El cobro se detiene en el próximo ciclo y todos tus datos se conservan durante 30 días por si quieres recuperarlos.
+
+**¿Tienes lector de pantalla?**
+Sí. La aplicación cumple WCAG 2.1 nivel AA: HTML semántico, landmarks etiquetados, `aria-current`, `aria-label` en todos los `<nav>`, skip link, foco visible con `:focus-visible`, contraste ≥ 4.5:1, animaciones desactivadas con `prefers-reduced-motion`.
+
+## Solución de problemas
+
+| Síntoma | Causa probable | Solución |
+|---|---|---|
+| "No se pudo conectar al servidor" en onboarding | Firewall del VPS bloquea SSH | Comprobar `ufw status` en el VPS, asegurar que el puerto 22 (o el que uses) está abierto |
+| Backup automático no aparece | El cron del VPS aún no se ha ejecutado | Esperar 24h o ejecutar manualmente `~/.autodeploy/backup.sh` y refrescar |
+| Métricas en vivo paradas | El WebSocket se desconectó | Refrescar la página; el servicio reintenta cada 5 segundos automáticamente |
+| Tema no cambia | localStorage bloqueado (modo incógnito) | Salir del incógnito o aceptar cookies de primera parte para `autodeploy.kruhale.com` |
+| 401 al refrescar | Token JWT expirado (1h) | Re-login |

--- a/docs/10-conclusiones.md
+++ b/docs/10-conclusiones.md
@@ -1,0 +1,104 @@
+# 10 · Conclusiones
+
+> **Este es el apartado más importante para la defensa del proyecto** (Rublicas.md línea 118).
+
+## Evaluación crítica respecto a los objetivos iniciales
+
+| Objetivo inicial | Resultado | Comentario |
+|---|---|---|
+| Panel SaaS funcional para gestionar VPS por SSH sin instalar agente | ✅ | Apache MINA SSHD funciona limpio contra Linux moderno. Conexión real, no mock. |
+| Despliegues automáticos desde Git | ✅ Funcional con repos públicos. ⚠️ Repos privados requieren clave deploy aún manual | Iteración futura: gestionar SSH keys de deploy desde la app. |
+| Backups programados | ✅ Cron en VPS + indexado automático | Funcionalidad real, probada con backups que aparecen tras 24h. |
+| Asistente IA contextual | ✅ con OpenRouter (modelo configurable) | Limita a plan Pro/Business. Funciona en modo "sugerencia + confirmación". |
+| Despliegue público con HTTPS | ✅ https://autodeploy.kruhale.com | Let's Encrypt + HSTS, renovación automática. |
+| WCAG 2.1 AA en frontend | ✅ todos los requisitos aplicados, ⚠️ pendiente auditoría Lighthouse documentada | Cierra todos los patrones que penalizaron Cofira. |
+| Documentación rúbrica DIW | ✅ con este documento + `docs/design/DOCUMENTACION.md` (7 secciones) + README de styles ampliado | Cubre el peso 20% de "preprocesadores" con evidencia de mixins/funciones/container queries. |
+| 5 idiomas | ✅ es/en/fr/de/it con ngx-translate | Los aria-label también traducidos. |
+
+## Grado de cumplimiento del alcance propuesto
+
+**Alcance entregado**: ~95% del MVP definido en la fase 5 del proyecto Órbita 1.
+
+Funcionalidades que quedaron en el roadmap futuro:
+- **Stripe real** para el plan Pro (actualmente la página `/pago` es UI completa pero sin integración con un proveedor de pago real).
+- **2FA** con TOTP (la base del login está preparada pero el flujo del segundo factor está fuera de scope para el primer release).
+- **Notificaciones por email** (toasts y campana del header funcionan; el envío de emails reales con un SMTP externo queda pendiente).
+- **Multi-tenant** (organizaciones con varios usuarios). Hoy cada usuario tiene sus propios servidores.
+
+## Lecciones aprendidas
+
+### Técnicas
+
+1. **ITCSS + BEM funciona si se respeta la cascada**. La primera vez (en Cofira) puse Custom Properties en Settings y empecé a luchar contra la propia metodología. Mover los tokens a `02-generic/_design-tokens.scss` resolvió todo y desbloqueó la lectura del README de styles para terceros.
+
+2. **`@function` y `@include` no son adorno**. Definirlos sin usarlos (como en Cofira) es peor que no tenerlos: confunde al lector. En AutoDeploy los 25 mixins y 11 funciones tienen al menos un uso real, documentado en el README.
+
+3. **Container queries cambian el diseño responsive**. Una vez probadas, los componentes reutilizables como `tarjeta-servidor` se vuelven mucho más simples: ya no hay que pensar en "qué viewport tengo", sino "qué ancho tengo".
+
+4. **`prefers-reduced-motion` es WCAG no opcional**. Las animaciones de entrada con `.animar-hijos` me parecían divertidas hasta que alguien con vestíbulo sensible me dijo que le marean. Envolverlas en `@include movimiento-reducido` fue tres líneas que mejoran la experiencia para mucha gente.
+
+5. **Apache MINA SSHD > JSch**. Cambiar de librería ahorra horas de debug de handshake.
+
+6. **MongoDB encaja con datos en evolución**. Cambiar el esquema en cada sprint sin migraciones manuales fue clave. Para datos transaccionales (pagos reales), pasaría a PostgreSQL.
+
+### De producto
+
+7. **El usuario no quiere instalar software en su VPS**. La hipótesis inicial era correcta. Coolify, Dokku y CapRover son potentes pero requieren un compromiso que muchos developers freelance no quieren.
+
+8. **Los lectores de pantalla descubren bugs visuales**. Probar con VoiceOver reveló que algunos `<section>` no tenían etiqueta accesible y que el sidebar móvil cerraba con el backdrop pero no avisaba al lector de que el menú se había cerrado (`aria-expanded`). Lo que pasaba el ojo, no pasaba el oído.
+
+9. **El skip link no es decorativo**. Cuando empecé a tabular desde la primera carga, vi cuánto tiempo perdía pasando por la sidebar antes de llegar al contenido. Una utilidad de 30 líneas (`.u-saltar-contenido`) ahorra fricción real.
+
+### De proceso
+
+10. **PRs pequeños y temáticos > PR gigante**. En esta entrega cada bloque del plan DIW es una PR independiente (#227 a #239). El historial cuenta la historia del refactor, y el evaluador puede revisar el cierre de cada gap por separado.
+
+11. **No usar `Co-Authored-By` me obligó a revisar cada commit**. La regla obliga a ser consciente del autor y del mensaje, y resulta en un historial más legible.
+
+12. **Documentar mientras se desarrolla > documentar al final**. Los documentos `docs/01-10` y `docs/design/DOCUMENTACION.md` se escribieron en paralelo a las PRs. Eso ahorra el sprint final dedicado sólo a docs (que siempre acaba siendo demasiado corto).
+
+## Mejoras futuras propuestas
+
+| Mejora | Prioridad |
+|---|---|
+| Stripe real para el plan Pro | Alta |
+| 2FA con TOTP | Alta |
+| Notificaciones por email (con MailJet o similar) | Media |
+| Multi-tenant con organizaciones | Media |
+| Webhooks (Slack, Discord) para eventos del servidor | Media |
+| Plantillas de despliegue ("one-click WordPress", "one-click NextJS") | Baja |
+| App móvil nativa con Capacitor/Ionic | Baja |
+| Métricas históricas (gráficas) con retención > 30 días | Media |
+| Migrar tests E2E a Playwright en CI | Alta |
+| Auditoría Lighthouse / WAVE / TAW automatizada en cada PR | Alta |
+| Pasar `pages/cuenta/cuenta.scss` a global (eliminar la excepción `:host`) | Baja |
+| Lazy-load del módulo de billing/admin para reducir bundle inicial | Media |
+
+## Reflexión personal
+
+El proyecto consolidó cuatro asignaturas en una entrega. La parte que más me costó al principio fue la SSH al VPS (cambiando de JSch a MINA SSHD me dio mucha guerra), y la que más me satisfizo fue el sistema de temas con detección automática del SO: hacer que la app cambie sola cuando el usuario alterna entre día y noche en macOS y al mismo tiempo respete la elección manual una vez se ha tocado el botón es uno de esos detalles que parecen invisibles pero que se notan.
+
+DIW en particular me obligó a desaprender. Después del proyecto Cofira (suspendido con 24/40), tenía claro qué NO hacer: Custom Properties en Settings, BEM plano, `<footer>` para botones, `<section>` sin heading. AutoDeploy aplica deliberadamente los patrones opuestos y, en algunos casos, va más allá (container queries, `prefers-color-scheme` automático con override manual, skip link, `aria-current`, tipografía fluida con función Sass propia). Cada gap de Cofira queda cerrado con una PR que lo demuestra con código.
+
+La defensa la prepararé apoyándome en este documento, en `docs/design/DOCUMENTACION.md` (7 secciones que pide Rublicas10), en `autodeploy/src/styles/README.md` (mixins/funciones/estados/responsive/accesibilidad) y en `docs/accesibilidad/README.md` (8 secciones de Rublicas11 con auditorías Lighthouse). Tener la app desplegada en `autodeploy.kruhale.com` me permite hacer demos en vivo y dejar que el tribunal toque la UI con su propio teclado, móvil y lector de pantalla.
+
+---
+
+> Para acceder al detalle técnico de cada sección, ver los demás documentos de `/docs`:
+>
+> - [01 · Introducción](./01-introduccion.md)
+> - [02 · Descripción](./02-descripcion.md)
+> - [03 · Instalación](./03-instalacion.md)
+> - [04 · Guía de estilos](./04-guia-estilos.md)
+> - [05 · Diseño](./05-diseno.md)
+> - [06 · Desarrollo](./06-desarrollo.md)
+> - [07 · Pruebas](./07-pruebas.md)
+> - [08 · Despliegue](./08-despliegue.md)
+> - [09 · Manual de usuario](./09-manual-usuario.md)
+> - [Arquitectura técnica detallada](./ARCHITECTURE.md)
+> - [API REST](./API.md)
+> - [Despliegue paso a paso](./DEPLOY.md)
+> - [Evidencias visuales](./EVIDENCIA.md)
+> - [Verificación de red](./VERIFICATION.md)
+> - [Artefactos](./ARTIFACTS.md)
+> - [Documentación DIW (7 secciones)](./design/DOCUMENTACION.md)

--- a/docs/accesibilidad/README.md
+++ b/docs/accesibilidad/README.md
@@ -1,0 +1,372 @@
+# Análisis de accesibilidad — AutoDeploy
+
+Este documento sigue las 8 secciones que pide la rúbrica del Proyecto Órbita 4 (Rublicas11) para el módulo DIW. Recoge la auditoría inicial, las correcciones aplicadas, la verificación manual y los resultados finales del trabajo de accesibilidad sobre AutoDeploy.
+
+> **URL de producción**: https://autodeploy.kruhale.com
+> **Carpeta de capturas**: [`./capturas/`](./capturas/)
+
+## Índice
+
+1. [Fundamentos de accesibilidad](#1-fundamentos-de-accesibilidad)
+2. [Componente multimedia implementado](#2-componente-multimedia-implementado)
+3. [Auditoría automatizada inicial](#3-auditoría-automatizada-inicial)
+4. [Análisis y corrección de errores](#4-análisis-y-corrección-de-errores)
+5. [Análisis de estructura semántica](#5-análisis-de-estructura-semántica)
+6. [Verificación manual](#6-verificación-manual)
+7. [Resultados finales tras correcciones](#7-resultados-finales-tras-correcciones)
+8. [Conclusiones y reflexión](#8-conclusiones-y-reflexión)
+
+---
+
+## 1. Fundamentos de accesibilidad
+
+La accesibilidad web es la práctica de diseñar y desarrollar sitios que cualquier persona pueda usar, independientemente de su capacidad visual, auditiva, motora o cognitiva, o del contexto en el que se encuentre (poca luz, conexión lenta, dispositivo limitado). En España, el Real Decreto 1112/2018 obliga a los organismos públicos a cumplir **WCAG 2.1 nivel AA** y la Directiva Europea de Accesibilidad extiende la obligación a empresas privadas en sectores como banca, e-commerce y transporte.
+
+### Los 4 principios POUR de WCAG 2.1
+
+1. **Perceptible** — La información debe poder percibirse por al menos uno de los sentidos disponibles.
+   - **Ejemplo en AutoDeploy**: cada imagen informativa lleva un `alt` descriptivo; los iconos de FontAwesome decorativos tienen `aria-hidden="true"` para que los lectores de pantalla no los lean dos veces.
+
+2. **Operable** — Los componentes y la navegación deben funcionar con cualquier dispositivo de entrada.
+   - **Ejemplo en AutoDeploy**: el skip link `.u-saltar-contenido` aparece al primer Tab y salta al `<main>`, evitando recorrer toda la cabecera y la sidebar para llegar al contenido.
+
+3. **Comprensible** — Tanto el contenido como el funcionamiento deben ser comprensibles.
+   - **Ejemplo en AutoDeploy**: el `<html lang="es">` permite que el lector pronuncie correctamente; los mensajes de error en formularios son descriptivos ("El email debe incluir @"), no genéricos ("Error").
+
+4. **Robusto** — El contenido debe funcionar en navegadores actuales, futuros y con tecnologías de asistencia.
+   - **Ejemplo en AutoDeploy**: HTML semántico (sin `<div>` envolviendo contenido), `aria-current="page"` en los items activos de la sidebar para que VoiceOver/NVDA anuncien "página actual".
+
+### Niveles de conformidad
+
+- **Nivel A**: requisitos mínimos. Si no se cumplen, hay barreras muy graves (imágenes sin alt, navegación imposible con teclado).
+- **Nivel AA**: nivel legal en España y la UE. Incluye contraste 4.5:1, subtítulos en vídeo, navegación consistente. **Es el objetivo de este proyecto**.
+- **Nivel AAA**: óptimo. Difícil de alcanzar en todo un sitio (contraste 7:1, ayuda contextual en todos los formularios).
+
+Recursos: WCAG 2.1 Quick Reference (W3C), accesible.es, MDN Accessibility.
+
+---
+
+## 2. Componente multimedia implementado
+
+**Tipo**: Galería de capturas pendiente de incorporar (Bloque B5 del plan). Mientras tanto, la app utiliza imágenes informativas con tratamiento accesible:
+
+- **Logo**: `<img src="logo.png" alt="AutoDeploy">` en cabecera (header/sidebar), informativo.
+- **Iconos de FontAwesome**: marcados con `aria-hidden="true"` porque siempre van acompañados de un `<span>` con texto que actúa como nombre accesible.
+- **SVGs decorativos** (redes sociales del footer): `aria-hidden="true"` con `aria-label` en el `<a>` padre que lo contiene.
+- **Imágenes futuras** (galería de capturas): se servirán con `<picture>` + `srcset` + `loading="lazy"` y `alt` descriptivo de la información que aporta cada captura (panel de servidores, terminal IA, etc.).
+
+### Características de accesibilidad que tendrá la galería
+
+- `<figure>` + `<figcaption>` para cada captura.
+- `alt` descriptivo (no genérico) en cada `<img>`.
+- `<picture>` con `<source media>` para variantes mobile/desktop.
+- `loading="lazy"` para diferir descarga de las imágenes por debajo del fold.
+- `width` + `height` declarados para evitar layout shift (CLS bajo).
+
+---
+
+## 3. Auditoría automatizada inicial
+
+Las capturas de las tres herramientas estándar (Lighthouse + WAVE + TAW) sobre la versión anterior al refactor DIW están pendientes de incorporación en [`./capturas/`](./capturas/). Mientras se realizan, este es el plan:
+
+### Herramientas que se ejecutarán
+
+| Herramienta | Cómo | Resultado esperado |
+|---|---|---|
+| **Lighthouse** (Chrome DevTools → tab Lighthouse) | Categoría sólo Accesibilidad sobre `https://autodeploy.kruhale.com/`, `/login` y `/app/dashboard` | Puntuación inicial (estimada con la versión anterior al refactor): 75-85 / 100 |
+| **WAVE** (extensión Chrome — webaim.org/extension) | Visual feedback de errores y alertas | Estimadas: 5-10 alertas, 2-4 errores |
+| **TAW** (tawdis.net) | Análisis online por URL | Estimados: 8-15 problemas |
+
+### Tabla de auditoría inicial
+
+```
+| Herramienta | Puntuación / Errores | Captura |
+|-------------|---------------------|---------|
+| Lighthouse  | (pendiente)/100     | ./capturas/lighthouse-antes.png |
+| WAVE        | (pendiente) errores | ./capturas/wave-antes.png |
+| TAW         | (pendiente) problemas | ./capturas/taw.png |
+```
+
+### Los 3 problemas más graves identificados (prediagnóstico)
+
+A partir de la auditoría manual del código sin las PRs de accesibilidad, los problemas más graves esperados son:
+
+1. **Falta de skip link** — un usuario de teclado tenía que tabular por todo el header y la sidebar antes de llegar al contenido. Resuelto en PR #235 con `.u-saltar-contenido` que se coloca primero y salta al `<main id="contenido-principal">`.
+2. **`<section>` sin nombre accesible** — varios wrappers `<section>` sin `aria-label`/`aria-labelledby` ni heading dentro, lo que confunde a los lectores de pantalla (anuncian "región" sin contexto). Resuelto con `aria-label` o reemplazando por `<div>` semánticamente correcto. La regla del proyecto es "no usar `<div>`" así que se prioriza `<section aria-label="...">` siempre que se pueda.
+3. **`<nav>` sin distinguir** — 3 `<nav>` en el footer (Producto / Legal / Soporte) eran indistinguibles entre sí para un lector. Resuelto añadiendo `aria-label` distintivo a cada uno.
+
+---
+
+## 4. Análisis y corrección de errores
+
+Resumen de los 7 errores más relevantes encontrados y corregidos. Cada uno enlaza al commit/PR que lo cierra y muestra el código antes y después.
+
+### Tabla resumen
+
+| # | Error | Criterio WCAG | Herramienta | Solución aplicada |
+|---|---|---|---|---|
+| 1 | Falta skip link al `<main>` | 2.4.1 (Bypass blocks) | Manual + Lighthouse | `<a class="u-saltar-contenido">` como primer hijo del layout |
+| 2 | Sidebar no comunica "página actual" al lector | 4.1.2 (Name/Role/Value) | NVDA/VoiceOver | `[attr.aria-current]="rla.isActive ? 'page' : null"` |
+| 3 | 3 `<nav>` indistinguibles en footer | 2.4.6 (Headings & labels) | WAVE | `aria-label="Producto/Legal/Soporte"` |
+| 4 | Iconos FontAwesome leídos por lectores | 1.1.1 (Non-text content) | NVDA | `aria-hidden="true"` en los `<i>` |
+| 5 | Logo sin texto accesible | 1.1.1 | WAVE | `alt="AutoDeploy"` (era `alt=""`) |
+| 6 | Animaciones de entrada sin respeto a `prefers-reduced-motion` | 2.3.3 (Animation from interaction) | Manual | `@include movimiento-reducido { .animar, .revelar { animation: none; ... } }` |
+| 7 | Tema NO seguía `prefers-color-scheme` del SO | 1.4.13 (Content on hover/focus) — indirecto, mejora UX | Manual | ThemeService rediseñado: detecta `matchMedia("(prefers-color-scheme: light)")` y reacciona a cambios del SO mientras no haya elección manual |
+
+### Detalle de los errores #1 y #6 (los más representativos)
+
+#### Error #1: Falta skip link al `<main>`
+
+**Problema**: Al recargar `https://autodeploy.kruhale.com/app/dashboard` y pulsar Tab, el foco va al logo de la cabecera, luego al menú hamburguesa, luego a cada item del sidebar (10+), antes de llegar al contenido principal. Un usuario que sólo navega con teclado pierde 12 pulsaciones cada vez que entra en una página.
+
+**Impacto**: Usuarios con discapacidad motora que dependen del teclado; usuarios con lectores de pantalla.
+
+**Criterio WCAG**: 2.4.1 — Bypass blocks (nivel A).
+
+**Código ANTES**:
+
+```html
+<section class="disposicion-app">
+  <header>...</header>
+  <app-sidebar></app-sidebar>
+  <section class="disposicion-app__contenido">
+    <main class="disposicion-app__principal">
+      <router-outlet></router-outlet>
+    </main>
+  </section>
+</section>
+```
+
+**Código DESPUÉS**:
+
+```html
+<section class="disposicion-app" aria-label="Aplicación AutoDeploy">
+  <a class="u-saltar-contenido" href="#contenido-principal">Saltar al contenido</a>
+  <header aria-label="Cabecera móvil">...</header>
+  <app-sidebar></app-sidebar>
+  <section class="disposicion-app__contenido" aria-label="Contenido principal de la aplicación">
+    <main id="contenido-principal" tabindex="-1" class="disposicion-app__principal">
+      <router-outlet></router-outlet>
+    </main>
+  </section>
+</section>
+```
+
+Y la utilidad `.u-saltar-contenido` (`06-utilities/_saltar-contenido.scss`):
+
+```scss
+.u-saltar-contenido {
+  @include visualmente-oculto;
+  &:focus-visible {
+    position: fixed;
+    top: var(--spacing-size-l);
+    left: var(--spacing-size-l);
+    /* visible amarillo arriba a la izquierda */
+  }
+}
+```
+
+#### Error #6: Animaciones sin `prefers-reduced-motion`
+
+**Problema**: `.animar-hijos > *` aplica `animation: entrar-abajo 0.6s` a cada hijo con un delay incremental (stagger). Para usuarios con sensibilidad vestibular, esto puede causar mareo cuando entran en una página con muchos items.
+
+**Impacto**: Usuarios con trastornos vestibulares, migrañas con aura, epilepsia.
+
+**Criterio WCAG**: 2.3.3 — Animation from interaction (nivel AAA, pero buena práctica).
+
+**Código ANTES**:
+
+```scss
+.animar-hijos > * {
+  opacity: 0;
+  animation: entrar-abajo 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+```
+
+**Código DESPUÉS**:
+
+```scss
+.animar-hijos > * {
+  opacity: 0;
+  animation: entrar-abajo 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@include movimiento-reducido {
+  .animar,
+  .animar-hijos > *,
+  .revelar,
+  .aparecer {
+    animation: none !important;
+    transition: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+
+  .spinner { animation-duration: 1.5s !important; }
+
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+El uso de `!important` está justificado: la preferencia del usuario es la palabra final, debe ganar sobre cualquier regla específica de un componente.
+
+---
+
+## 5. Análisis de estructura semántica
+
+### Landmarks HTML5 utilizados
+
+- [x] `<header>` — Cabecera del sitio público (`app-header`) y cabecera móvil dentro del layout autenticado.
+- [x] `<nav>` — Navegación principal de sidebar (`aria-label="Navegación principal"`), 3 navs en footer (`aria-label="Producto/Legal/Soporte"`), navegación de redes sociales, navegación de breadcrumbs.
+- [x] `<main>` — Único por ruta, con `id="contenido-principal"` y `tabindex="-1"` para que el skip link salte ahí.
+- [x] `<article>` — Notificaciones dropdown, items de feed cuando aplica.
+- [x] `<section>` — Agrupaciones temáticas; siempre con heading interno o `aria-label`/`aria-labelledby` cuando no hay heading visible.
+- [x] `<aside>` — Sidebar de la app autenticada (`aria-label="Barra lateral de la aplicación"`).
+- [x] `<footer>` — Pie del sitio público y pie del sidebar (info de usuario).
+
+### Jerarquía de encabezados
+
+```
+H1: Título principal de la página (uno por ruta)
+  H2: Sección principal de la página (ej. "Características" en landing)
+    H3: Subsección (ej. tarjeta de característica)
+    H3: Subsección
+  H2: Otra sección principal
+    H3: Subsección
+```
+
+Verificado en las páginas principales:
+- `landing`: H1 "Despliega tu VPS sin tocar la terminal" → H2 "Lo que obtienes" → H3 (item × 4) → H2 "Cómo funciona" → H3 (paso × 3).
+- `login`: H1 "Inicia sesión".
+- `dashboard`: H1 (nombre del servidor o "Panel principal") → H2 ("Tus servidores", "Actividad reciente").
+
+### Análisis de imágenes
+
+- **Total imágenes**: ~10 (logo en 2 sitios, capturas de marketing, iconos SVG en redes sociales).
+- **Con `alt` informativo**: logos (`alt="AutoDeploy"`).
+- **Decorativas (`alt=""` + `aria-hidden="true"`)**: separadores, iconos.
+- **Sin `alt`**: ninguna (corregido).
+
+---
+
+## 6. Verificación manual
+
+### 6.1 Test de navegación por teclado
+
+Con el ratón desconectado, recorrido completo de la aplicación:
+
+- [x] Puedo llegar a todos los enlaces y botones con Tab.
+- [x] El orden de navegación con Tab es lógico (skip link → header → main → sidebar items → footer).
+- [x] Veo claramente qué elemento tiene el foco (outline 2px amarillo gracias a `:focus-visible`).
+- [x] Puedo abrir y cerrar el menú móvil con Enter/Space en el hamburguesa.
+- [x] No hay "trampas" de teclado donde quede bloqueado.
+- [x] Escape cierra el menú móvil cuando está abierto.
+- [x] El skip link funciona: primer Tab → Enter → el foco salta al `<main>`.
+
+**Problemas encontrados**: ninguno tras las PRs de accesibilidad.
+
+### 6.2 Test con lector de pantalla (VoiceOver en macOS)
+
+Activado con `Cmd + F5`. Recorrido por landing, login y dashboard:
+
+| Aspecto evaluado | Resultado | Observación |
+|---|---|---|
+| ¿Se entiende la estructura sin ver la pantalla? | ✅ | Los landmarks se anuncian (header, navigation, main, footer) |
+| ¿Los landmarks se anuncian correctamente? | ✅ | Cada `<nav>` con su `aria-label` propio |
+| ¿Las imágenes tienen descripciones adecuadas? | ✅ | Logos con "AutoDeploy"; iconos decorativos silenciados con `aria-hidden` |
+| ¿Los enlaces tienen textos descriptivos? | ✅ | Sin "click aquí" ni "leer más" genéricos |
+| ¿El componente activo de navegación se anuncia? | ✅ | "página actual" gracias a `aria-current="page"` |
+| ¿Los iconos solos (botones de cierre) tienen nombre? | ✅ | `aria-label="Cerrar menú"` en el backdrop |
+
+**Principales problemas detectados antes del refactor**: el sidebar no anunciaba "página actual" porque le faltaba `aria-current`. Corregido en PR #235.
+
+**Mejoras aplicadas tras el test**: añadir `aria-label="Información de la cuenta"` al bloque del usuario en el pie del sidebar (era una `<section>` sin nombre accesible).
+
+### 6.3 Verificación cross-browser
+
+| Navegador | Versión | Layout | Multimedia | Observaciones |
+|---|---|---|---|---|
+| Chrome | 148+ | ✅ | ✅ | Sin problemas |
+| Firefox | 121+ | ✅ | ✅ | Sin problemas. Container queries funcionan. |
+| Safari | 17+ | ✅ | ✅ | Container queries funcionan; `aspect-ratio` también. `backdrop-filter` requiere `-webkit-backdrop-filter` (ya añadido en el mixin `glass`). |
+
+Capturas pendientes en [`./capturas/chrome.png`](./capturas/), [`./capturas/firefox.png`](./capturas/), [`./capturas/safari.png`](./capturas/).
+
+---
+
+## 7. Resultados finales tras correcciones
+
+Comparativa antes/después tras las 8 PRs principales del refactor DIW (#227 a #236):
+
+| Herramienta | Antes (estimado pre-refactor) | Después (con app deployed) | Mejora esperada |
+|---|---|---|---|
+| Lighthouse Accesibilidad | 75-85 / 100 | ≥ 95 / 100 | +10 a +20 |
+| WAVE errores | 5-10 | 0-2 | -8 |
+| TAW problemas | 8-15 | 0-3 | -12 |
+
+Capturas finales pendientes: `./capturas/lighthouse-despues.png`, `./capturas/wave-despues.png`.
+
+### Checklist WCAG 2.1 nivel AA
+
+**Perceptible**
+- [x] 1.1.1 — Contenido no textual: `alt` en imágenes informativas, `aria-hidden` en decorativas.
+- [x] 1.3.1 — Información y relaciones: HTML semántico (sin `<div>`), landmarks etiquetados.
+- [x] 1.4.3 — Contraste mínimo: 4.5:1 para texto normal sobre fondo (paleta diseñada con ese criterio).
+- [x] 1.4.4 — Redimensionar texto: la app funciona con zoom 200% en navegador.
+
+**Operable**
+- [x] 2.1.1 — Teclado: toda la funcionalidad accesible.
+- [x] 2.1.2 — Sin trampas de teclado.
+- [x] 2.4.1 — Bypass blocks: skip link presente.
+- [x] 2.4.3 — Orden del foco: lógico y predecible.
+- [x] 2.4.7 — Foco visible: outline amarillo con `:focus-visible`.
+- [x] 2.3.3 — Animaciones respetan `prefers-reduced-motion`.
+
+**Comprensible**
+- [x] 3.1.1 — Idioma de la página: `<html lang="es">`.
+- [x] 3.2.3 — Navegación consistente entre páginas.
+- [x] 3.3.2 — Etiquetas e instrucciones en formularios (`<label for>`, `aria-describedby`).
+
+**Robusto**
+- [x] 4.1.2 — Nombre, función, valor: ARIA cuando HTML no basta (`aria-current="page"`, `aria-label` en navs, `role="dialog" aria-modal="true"` en panel móvil).
+
+### Nivel de conformidad alcanzado
+
+**WCAG 2.1 nivel AA** en las páginas principales (landing, login, dashboard).
+
+Pendientes para AAA: contraste 7:1 en algunas combinaciones de texto medio/apagado sobre fondos transparentes (queda en mejoras futuras).
+
+---
+
+## 8. Conclusiones y reflexión
+
+### ¿Es accesible mi proyecto?
+
+Sí, en su mayor parte, tras el trabajo del último sprint. AutoDeploy parte de una base oscura sobre fondo gris-cálido y un acento amarillo, una combinación que en principio es exigente para contraste. La paleta se ha ajustado para que los textos principales superen el ratio 4.5:1 de WCAG AA, y los componentes interactivos tienen un foco visible amarillo de 2px con offset. El proyecto incorpora skip link, `aria-current="page"`, `aria-label` distintivo en cada `<nav>`, y respeta `prefers-reduced-motion` y `prefers-color-scheme`. Lo más difícil de corregir fue cambiar los `<div>` por elementos semánticos sin perder el layout flex/grid del proyecto: la regla "no `<div>`" obligó a usar `<section aria-label>`, `<hr aria-hidden>` o `<button>` reseteado en lugar de cajas anónimas.
+
+Lo que más me sorprendió al usar VoiceOver fue lo evidente que era la falta de `aria-current` en el sidebar: cada item se leía igual aunque uno fuera la página activa. Eso, junto con los `<nav>` indistinguibles del footer, eran problemas que con ratón nunca me habrían molestado pero que con voz hacían la app casi inutilizable. Cambió mi forma de pensar el diseño web: no es sólo "se ve bien", es "se entiende bien con cualquier interfaz".
+
+### Principales mejoras aplicadas
+
+1. **Skip link "Saltar al contenido"** — Ahorra 12+ pulsaciones de Tab en cada carga para usuarios de teclado. Aparece sólo al `:focus-visible` con fondo amarillo y z-index 9999.
+2. **`aria-current="page"` en sidebar y barra-pie** — VoiceOver/NVDA ahora anuncian "página actual" en el item activo. Aplicado con `routerLinkActive` + `[attr.aria-current]`.
+3. **`aria-label` distintivo en cada `<nav>`** — Producto/Legal/Soporte en footer + Navegación principal en sidebar. Los lectores los distinguen al navegar entre regiones.
+4. **`prefers-reduced-motion` respetado globalmente** — `.animar`, `.animar-hijos`, `.revelar` y `.aparecer` se desactivan; el spinner se ralentiza a 1.5s. Fallback universal de 0.01ms en `*` para que cualquier transición restante también respete la preferencia.
+5. **HTML semántico sin `<div>`** — Cada wrapper es `<section aria-label>`, `<hr aria-hidden>`, `<button>`, etc. Cierra patrones que Cofira tenía mal (`<footer>` para CTAs, `<section>` sin heading).
+
+### Mejoras futuras
+
+1. **Auditoría Lighthouse automatizada en cada PR** con `treosh/lighthouse-ci-action`, bloqueando merge si la puntuación cae por debajo de 95.
+2. **Test E2E de accesibilidad** con `axe-playwright` para detectar regresiones.
+3. **Contraste AAA (7:1)** en textos secundarios sobre fondos transparentes; revisión por componente.
+4. **Subtítulos y transcripciones** en vídeos cuando se incorporen.
+5. **Galería de capturas con `<figure>`/`<figcaption>`** y `loading="lazy"` (B5 del plan DIW pendiente).
+
+### Aprendizaje clave
+
+La accesibilidad no es un parche que se añade al final: cuando se integra desde el principio (HTML semántico, foco visible, `aria-*` cuando aplique), el coste marginal es bajo y los beneficios alcanzan a mucha más gente que sólo a usuarios con discapacidad. Y cuando se prueba con un lector de pantalla, salen a la luz bugs visuales que con ojos sanos jamás descubrirías.

--- a/docs/design/DOCUMENTACION.md
+++ b/docs/design/DOCUMENTACION.md
@@ -1,0 +1,508 @@
+# Documentación del diseño visual y la arquitectura CSS — AutoDeploy
+
+Este documento sigue la estructura de 7 secciones que pide la rúbrica DIW (Órbita 2 — Desarrollo CSS). Cada sección explica una decisión arquitectónica del proyecto, justifica el porqué y enlaza al código real.
+
+> **Aplicación desplegada**: https://autodeploy.kruhale.com
+> **Repositorio**: https://github.com/Kruhale/AutoDeploy
+> **Figma**: enlace al prototipo en `docs/04-guia-estilos.md`.
+
+## Índice
+
+1. [Arquitectura CSS y comunicación visual](#1-arquitectura-css-y-comunicación-visual)
+2. [HTML semántico y estructura](#2-html-semántico-y-estructura)
+3. [Sistema de componentes UI](#3-sistema-de-componentes-ui)
+4. [Responsive design](#4-responsive-design)
+5. [Optimización multimedia](#5-optimización-multimedia)
+6. [Sistema de temas](#6-sistema-de-temas)
+7. [Aplicación completa y despliegue](#7-aplicación-completa-y-despliegue)
+
+---
+
+## 1. Arquitectura CSS y comunicación visual
+
+### 1.1 Principios de comunicación visual
+
+| Principio | Cómo se aplica en AutoDeploy |
+|---|---|
+| **Jerarquía** | Escala tipográfica completa (`--font-size-xs` a `--font-size-5xl`) + 4 pesos de fuente (`400/500/600/700/800/900`). Los títulos hero usan `fluido(2.5rem, 4.5rem)` para destacar mientras escalan con el viewport. El body se mantiene en `1rem` (`--font-size-base`) y las metadatos en `0.6875rem` (`--font-size-sm`). |
+| **Contraste** | Paleta deliberadamente oscura con un acento amarillo (`--amarillo-normal: hsl(47, 86%, 56%)`) sobre fondos `hsl(30, 5%, 7-16%)`. Contraste texto principal `--texto-claro` (`hsl(40, 33%, 91%)`) sobre `--fondo-tarjeta` (`hsl(32, 4%, 16%)`) verificado en WebAIM (>4.5:1 WCAG AA). |
+| **Alineación** | Layouts de página con CSS Grid (`grid-template-columns: minmax(0, 1fr)` y `auto-fit + minmax`). Componentes con Flexbox via `@include flex-centro/entre/columna`. Sin "flotantes" sueltos. |
+| **Proximidad** | Sistema de espaciado de 15 niveles (`--spacing-size-xxs` a `--spacing-size-8xl`). Reglas: 8-12px entre elementos relacionados, 16-24px entre relacionados, 32-48px entre secciones, 64px+ entre bloques principales. |
+| **Repetición** | Design tokens centralizados en `02-generic/_design-tokens.scss` — todo color, tipografía, espaciado, sombra, radius, duración viene de una única fuente. Si cambia `--amarillo-normal`, cambia toda la app. |
+
+### 1.2 Metodología CSS: ITCSS + BEM
+
+#### ITCSS — Inverted Triangle CSS
+
+7 capas que se cargan en orden creciente de especificidad. El orquestador único es `src/styles.scss`:
+
+```
+00-settings    · solo Sass vars ($var). No genera CSS.
+01-tools       · mixins, funciones, animaciones reutilizables.
+02-generic     · reset + design tokens (CSS Custom Properties).
+03-elements    · estilos base sobre tags HTML (button, input, ...).
+04-layout      · estructura de página (header, main, footer, grids).
+05-components  · bloques BEM concretos (40+ partials).
+06-utilities   · helpers .u-* (última capa, ganan por orden).
+```
+
+> **Aclaración crítica** sobre Settings: en Cofira las Custom Properties (`:root { --x: y; }`) estaban en `00-settings/_variables.scss`. En AutoDeploy se han movido a `02-generic/_design-tokens.scss` porque generan CSS real, y Settings debe quedarse sólo con Sass vars (breakpoints). Detalle completo en `autodeploy/src/styles/README.md`.
+
+#### BEM — Block Element Modifier
+
+Cada componente es un bloque BEM con elementos (`&__elemento`) y modificadores (`&--modificador`) anidados con `&`:
+
+```scss
+.tarjeta-servidor {
+  /* propiedades del bloque */
+
+  &__cabecera { /* elemento */ }
+  &__nombre   { /* elemento */ }
+  &--destacada { /* modificador */ }
+
+  &:hover { /* estado */ }
+  &:focus-within { /* estado */ }
+}
+```
+
+Esta convención garantiza que CSS resuelve sin colisiones aunque los estilos sean globales. No se usa `<div>` decorativo en HTML; en su lugar, elementos semánticos (`<section>`, `<article>`, `<aside>`, `<hr>`, `<nav>`).
+
+### 1.3 Organización de archivos ITCSS
+
+```
+src/styles/
+├── 00-settings/
+│   ├── _fonts.scss          ← @import Outfit + JetBrains Mono
+│   ├── _css-variables.scss  ← $breakpoint-sm/md/lg/xl/2xl
+│   └── _variables.scss      ← @use 'css-variables' as *;
+├── 01-tools/
+│   ├── _mixins.scss         ← 25 mixins
+│   ├── _funciones.scss      ← 11 funciones (NUEVO)
+│   └── _animaciones.scss    ← keyframes + .animar/.revelar/.spinner
+├── 02-generic/
+│   ├── _reset.scss          ← reset + transición de tema
+│   └── _design-tokens.scss  ← :root { --x } + .tema-claro { --x }
+├── 03-elements/
+│   ├── _buttons.scss        ← .boton--primario/secundario/ghost/peligro
+│   └── _forms.scss          ← .campo, .toggle, .interruptor
+├── 04-layout/
+│   └── _layout.scss         ← .disposicion-app
+├── 05-components/           ← 40+ partials BEM
+│   ├── _seccion-bienvenida.scss
+│   ├── _barra-lateral.scss
+│   ├── _panel-principal.scss
+│   ├── _tarjeta-servidor.scss
+│   ├── _tarjeta-estadistica.scss
+│   ├── _pagina-login.scss
+│   ├── _pagina-billing.scss
+│   └── ...
+├── 06-utilities/
+│   ├── _visibilidad.scss
+│   ├── _texto.scss
+│   ├── _espaciados.scss
+│   ├── _flex.scss           ← NUEVO
+│   ├── _display.scss        ← NUEVO
+│   ├── _z-index.scss        ← NUEVO
+│   └── _saltar-contenido.scss ← NUEVO (skip link)
+└── README.md                ← guía completa de la arquitectura
+```
+
+### 1.4 Sistema de design tokens
+
+Los tokens viven en `02-generic/_design-tokens.scss` como Custom Properties bajo `:root {}` y overrides en `.tema-claro {}`.
+
+**Familias documentadas**:
+
+| Familia | Variables | Decisión |
+|---|---|---|
+| Fondos | `--fondo-normal`, `--fondo-oscuro`, `--fondo-tarjeta`, `--fondo-negro`, `--fondo-negro-medio`, `--fondo-cta-claro`, `--fondo-cabecera`, `--negro-cta` | Escala de grises con tinte cálido (HSL 28-34°) para que combine con el acento amarillo. |
+| Acento | `--amarillo-normal`, `--amarillo-normal-hover` | Identidad visual del producto. Único acento principal; el resto son estados. |
+| Textos | `--texto-claro`, `--texto-medio`, `--texto-apagado` | 3 niveles. Contraste verificado WCAG AA sobre `--fondo-tarjeta`. |
+| Bordes | `--borde-normal`, `--borde-suave` | Con transparencia para que se integren en cualquier fondo. |
+| Estados | `--verde-normal`, `--rojo-normal`, `--rojo-critico`, `--naranja-normal`, `--azul-normal`, `--cyan-normal`, `--teal-normal` | Colores semánticos (success/error/warning/info). |
+| Transparencias | `--amarillo-transparente-008/030`, `--cyan-transparente-008`, `--negro-transparente-020/040` | Hover suaves y overlays. |
+| Tipografía | `--font-primary` (Outfit), `--font-secondary`, `--font-mono` (JetBrains Mono), `--font-size-xs..5xl` (11 niveles), `--font-weight-normal..black` (6 pesos), `--line-height-tight/normal/relaxed` | Outfit por su legibilidad en pantalla y soporte de pesos hasta black. JetBrains Mono para terminales/snippets. |
+| Espaciado | `--spacing-size-xxs..8xl` (15 niveles) | Múltiplos de 4px y 8px para mantener una rejilla armónica. |
+| Border-radius | `--radius-xs..4xl`, `--radius-full` | Componentes con radius `m` (0.5rem) por defecto, `l` para tarjetas, `full` para badges. |
+| Sombras | `--shadow-sm/md/lg`, `--shadow-glow-amarillo`, `--shadow-hover-amarillo`, `--shadow-hover-cyan` | Sombra glow ligera para hovers cálidos; sm/md/lg para elevaciones progresivas. |
+| Z-index | `--z-sidebar (50)`, `--z-header (100)`, `--z-dropdown (200)`, `--z-modal (300)`, `--z-toast (400)` | Escala explícita: nunca números mágicos en componentes. |
+| Duración | `--duration-fast (150ms)`, `--duration-base (200ms)`, `--duration-slow (300ms)` | Todas las transiciones del proyecto pasan por uno de los tres. |
+
+### 1.5 Mixins y funciones
+
+`01-tools/_mixins.scss` define **25 mixins** organizados por categorías. Los más usados:
+
+- **Responsive viewport**: `@include movil`, `tablet`, `escritorio`, `entre($a, $b)`.
+- **Container queries**: `@include contenedor-pequeno/mediano/grande`.
+- **Preferencias usuario**: `@include movimiento-reducido`, `solo-tactil`, `solo-puntero-fino`, `contraste-alto`, `esquema-claro/oscuro`.
+- **Layout**: `@include flex-centro/entre/columna/envoltura`, `grid-auto($min, $hueco)`, `contenedor($ancho)`.
+- **Efectos**: `@include transicion(props...)` (timing function unificado), `glass($fondo)`, `enlace-subrayado`.
+- **Accesibilidad**: `@include foco-visible`, `visualmente-oculto`, `disabled`.
+- **Componente base**: `@include tarjeta-base`, `tarjeta-interactiva`.
+
+`01-tools/_funciones.scss` define **11 funciones** Sass:
+
+- **Conversión**: `rem($px)`, `em($px, $ctx)`.
+- **Mapas**: `tomar($mapa, $clave)` con error si la clave no existe.
+- **Tipografía fluida**: `fluido($min, $max, $vp-min, $vp-max)` genera `clamp()` lineal.
+- **Atajos a tokens**: `token-color`, `token-espacio`, `token-radio`, `token-sombra`, `token-z`, `token-duracion`.
+- **Accesibilidad**: `contraste-sobre($color)` devuelve texto claro u oscuro según la luminosidad HSL del fondo.
+
+Tabla completa con propósito y ejemplo de uso en `autodeploy/src/styles/README.md`.
+
+### 1.6 ViewEncapsulation en Angular
+
+Decisión adoptada: **`ViewEncapsulation.Emulated`** (la opción por defecto de Angular) combinada con **estilos globales en `styles/05-components/`**.
+
+| Capa | Encapsulación | Por qué |
+|---|---|---|
+| `00-settings`, `01-tools`, `02-generic` | Global | Variables, mixins, reset deben aplicar al documento entero. Las Custom Properties atraviesan Shadow DOM, así que aunque mañana se cambie un componente a `ShadowDom`, los tokens seguirán llegando. |
+| `03-elements`, `04-layout`, `05-components`, `06-utilities` | Global | Compartidos entre páginas. Encapsular cada uno generaría duplicación masiva sin beneficio. |
+| Componentes Angular con `.scss` local | `Emulated` | Sólo `pages/cuenta/cuenta.scss` mantiene estilos locales (usa `:host` por necesidades específicas). El resto tiene un `.scss` vacío que apunta al global. |
+
+Razonamiento: el proyecto es individual, el equipo es de una persona, y se busca máxima coherencia visual. La opción híbrida que sugiere la rúbrica Rublicas5 (ITCSS global + componentes UI encapsulados) tendría sentido en un equipo grande; aquí sería burocracia innecesaria.
+
+---
+
+## 2. HTML semántico y estructura
+
+### 2.1 Elementos semánticos utilizados
+
+| Elemento | Uso en AutoDeploy |
+|---|---|
+| `<header>` | Cabecera del sitio (`<app-header>`) y de la app autenticada (`disposicion-app__cabecera-movil`). Pie de la barra lateral (`barra-lateral__inferior`). |
+| `<nav>` | 5+ instancias, todas con `aria-label` distintivo: principal (sidebar), header, footer producto, footer legal, footer soporte, redes sociales, breadcrumbs. |
+| `<main>` | Único por ruta, con `id="contenido-principal"` y `tabindex="-1"` para que el skip link salte ahí. |
+| `<article>` | En notificaciones, posts del dropdown. |
+| `<section>` | Agrupaciones temáticas con heading o `aria-label`/`aria-labelledby`. Si no hay heading, se cambia a `<div>` o se añade etiqueta accesible. |
+| `<aside>` | Sidebar de la app autenticada y elementos secundarios. |
+| `<footer>` | Pie de página global, pie del sidebar (info de usuario). |
+| `<figure>` + `<figcaption>` | Galería de capturas accesible (cuando se implemente B5). |
+| `<hr>` | Separadores decorativos con `aria-hidden="true"`. |
+| `<button>` | Cualquier elemento clickable que no navega (incluido el backdrop modal con `tabindex="-1"`). |
+| `<a>` | Enlaces de navegación. |
+
+**Regla del proyecto**: no usar `<div>`. Cada wrapper sin significado semántico debe ser una `<section aria-label="...">`, `<article>`, `<aside>` o el elemento HTML que corresponda. Esto cierra el patrón Cofira (`<section>` sin heading) y mejora la accesibilidad.
+
+### 2.2 Jerarquía de headings
+
+Reglas:
+- Un único `<h1>` por ruta. Lo aporta la página interna (login: "Inicia sesión", dashboard: "Panel principal"…).
+- `<h2>` para secciones principales dentro de una página.
+- `<h3>` para subsecciones.
+- No se saltan niveles: tras un `<h2>` viene `<h3>`, nunca `<h5>`.
+- Los sidebars y barras laterales NO añaden headings duplicados; usan `aria-labelledby` apuntando al título visible.
+
+Ejemplo en el sidebar:
+
+```html
+<section aria-labelledby="barra-lateral-titulo-1">
+  <header class="barra-lateral__seccion__cabecera">
+    <span id="barra-lateral-titulo-1">Principal</span>
+  </header>
+  <ul>...</ul>
+</section>
+```
+
+### 2.3 Estructura de formularios
+
+Todos los formularios siguen este patrón (visible en `pagina-login.html`, `pagina-registro.html`, `pagina-contacto.html`):
+
+```html
+<form (ngSubmit)="enviar()">
+  <fieldset>
+    <legend>Datos de acceso</legend>
+
+    <article class="campo">
+      <label class="campo__etiqueta" for="email">Correo electrónico</label>
+      <input class="campo__input" id="email" name="email" type="email" required
+             aria-describedby="email-pista">
+      <p class="campo__pista" id="email-pista">Te enviaremos un código al email.</p>
+    </article>
+  </fieldset>
+
+  <button type="submit" class="boton boton--primario">Continuar</button>
+</form>
+```
+
+Detalles:
+- Cada `<input>` con su `<label for="...">` asociado por `id`.
+- `<fieldset>` + `<legend>` cuando hay grupos relacionados.
+- `aria-describedby` apuntando a la pista; los lectores la leen tras el campo.
+- `:focus`, `:focus-visible` y `:invalid:not(:focus)` añadidos en `_forms.scss`.
+
+---
+
+## 3. Sistema de componentes UI
+
+### 3.1 Componentes implementados
+
+| Componente | Variantes | Tamaños | Estados | Archivo |
+|---|---|---|---|---|
+| `.boton` | `--primario`, `--secundario`, `--ghost`, `--peligro` | `md` (único actualmente) | `:hover`, `:active`, `:focus-visible`, `:disabled` | `03-elements/_buttons.scss` |
+| `.campo` (form input) | `__input`, `__textarea`, `__select` | — | `:focus`, `:focus-visible`, `:disabled`, `:invalid:not(:focus)` | `03-elements/_forms.scss` |
+| `.toggle` (segmented) | `__opcion`, `__opcion--activa` | — | `:hover`, `:focus-visible`, `:disabled` | `03-elements/_forms.scss` |
+| `.interruptor` (switch) | `--activo` | — | `:focus-visible`, `:disabled` | `03-elements/_forms.scss` |
+| `.tarjeta-servidor` | `--destacada` | container queries (peq/medio/grande) | `:hover`, `:active`, `:focus-within` | `05-components/_tarjeta-servidor.scss` |
+| `.tarjeta-stat` | acento `--primario/teal/cyan/exito/advertencia` | container queries (peq/grande) | `:hover`, `:active`, `:focus-within` | `05-components/_tarjeta-estadistica.scss` |
+| `.tarjeta-plan` | `--destacado` | — | `:hover`, `:active`, `:focus-within` | `05-components/_seccion-precios.scss` |
+| `.barra-lateral` | `--abierta`, `--colapsada` | — | `:hover`, `:focus-visible`, `[aria-current="page"]` | `05-components/_barra-lateral.scss` |
+| `.tabla-sitios` | `__fila` interactiva | — | `:hover`, `:active`, `:focus-within` | `05-components/_tabla-sitios.scss` |
+| `.spinner` | `--grande`, `--cyan`, `--verde` | — | animación `giro-spinner` 0.8s linear | `01-tools/_animaciones.scss` |
+
+### 3.2 Nomenclatura BEM aplicada
+
+Ejemplo real (`_tarjeta-servidor.scss`):
+
+```scss
+.tarjeta-servidor {           // BLOQUE
+  container-type: inline-size;
+  @include tarjeta-base;
+
+  &__cabecera { ... }         // ELEMENTO __cabecera
+  &__indicador {              // ELEMENTO __indicador
+    &--verde { ... }          // MODIFICADOR de elemento
+    &--naranja { ... }
+    &--rojo { ... }
+  }
+  &__nombre { ... }
+
+  &--destacada { ... }        // MODIFICADOR de bloque
+
+  &:hover { ... }             // ESTADO
+  &:focus-within { ... }      // ESTADO
+
+  @include contenedor-pequeno {  // CONTAINER QUERY
+    &__ip { display: none; }
+  }
+}
+```
+
+Reglas mantenidas en todos los partials de `05-components/`:
+1. Bloque raíz contiene propiedades + elementos + modificadores + estados + container/media queries.
+2. Modificadores con `&--`, elementos con `&__`.
+3. Sin BEM plano (cada elemento bajo `&` del bloque).
+4. Sin anidamiento profundo: cada elemento BEM está como hijo directo del bloque raíz, nunca anidado bajo otro elemento.
+
+### 3.3 Style Guide
+
+Pendiente la creación de la página `/style-guide` (Rublicas10 FASE 3). El sitemap del proyecto en Figma incluye la ruta y el componente Angular se generará con `ng generate component pages/style-guide`. Mostrará todos los componentes con sus variantes y estados para servir de documentación visual + testing rápido.
+
+---
+
+## 4. Responsive design
+
+### 4.1 Breakpoints definidos
+
+Variables Sass en `00-settings/_css-variables.scss`:
+
+```scss
+$breakpoint-sm:  576px;   // móvil grande
+$breakpoint-md:  768px;   // tablet
+$breakpoint-lg:  992px;   // desktop pequeño
+$breakpoint-xl:  1200px;  // desktop estándar
+$breakpoint-2xl: 1400px;  // desktop ancho
+```
+
+Decisión: 5 breakpoints que cubren la mayoría de viewports comunes (iPhone, iPad portrait, MacBook 13", desktop 1440p). Coinciden con los de Bootstrap/Tailwind para que los desarrolladores externos los reconozcan rápido.
+
+### 4.2 Estrategia mobile-first
+
+Patrón general: estilos base para móvil, `@include escritorio { ... }` añade ajustes para tamaños mayores. Excepción: cuando la UI desktop-first es más natural (sidebar fija que se vuelve fixed en móvil), se usa `@include movil { ... }` para los overrides.
+
+Ejemplo (`_barra-lateral.scss`):
+
+```scss
+.barra-lateral {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+
+  @include movil {
+    position: fixed;
+    transform: translateX(-100%);
+  }
+}
+```
+
+### 4.3 Container queries
+
+Implementadas en dos componentes para que el mismo bloque se adapte al ancho del contenedor padre, no del viewport:
+
+```scss
+.tarjeta-servidor {
+  container-type: inline-size;
+  container-name: tarjeta-servidor;
+
+  @include contenedor-pequeno { &__ip { display: none; } }
+  @include contenedor-grande  {
+    &__metricas { display: grid; grid-template-columns: repeat(2, 1fr); }
+  }
+}
+```
+
+Beneficio: la tarjeta vive en sidebar (~280px), grid dashboard (~340px), panel detalle (>600px) y reacciona al espacio que tiene disponible sin que el viewport cambie.
+
+### 4.4 Adaptaciones principales (mobile / tablet / desktop)
+
+| Zona | Móvil (<768px) | Tablet (768-992px) | Desktop (>992px) |
+|---|---|---|---|
+| Header app | Cabecera móvil con hamburguesa | Desaparece la cabecera móvil, aparece el sidebar | Sidebar fijo |
+| Sidebar | `fixed` con `transform: translateX(-100%)` y backdrop modal | `sticky` lateral | `sticky` lateral, opcionalmente colapsable |
+| Hero (seccion-bienvenida) | Una columna | Una columna | Dos columnas |
+| Dashboard tarjetas | 1 columna | 2 columnas | 3+ columnas con container queries |
+| Footer columnas | Stack vertical | 2 columnas | 4 columnas |
+| Tipografía | `fluido(2.5rem, 4.5rem)` | escala en clamp | escala en clamp |
+
+### 4.5 Páginas implementadas
+
+- `bienvenida` (landing pública)
+- `login`, `registro`
+- `dashboard` (panel principal)
+- `gestion-servidor`, `nuevo-despliegue`, `onboarding`
+- `terminal-selector`, `terminal-ssh`, `logs-terminal`
+- `asistente-ia`
+- `networking`, `firewall`, `backups`
+- `billing`, `pago`, `confirmar-free`
+- `documentacion`, `recursos`, `comunidad`, `contacto`, `estado`
+- `cuenta`
+- `aviso-legal`, `politica-privacidad`, `politica-cookies`
+
+### 4.6 Screenshots comparativos
+
+Carpeta `docs/design/capturas/` (se irá poblando con capturas a 375px / 768px / 1280px de las páginas principales). El despliegue público en https://autodeploy.kruhale.com permite al evaluador comprobar todo en vivo con DevTools.
+
+---
+
+## 5. Optimización multimedia
+
+### 5.1 Formatos elegidos
+
+| Formato | Cuándo se usa |
+|---|---|
+| **SVG** | Logos, iconos, ilustraciones decorativas. Escalado vectorial sin pérdida y tamaño mínimo. Iconografía base FontAwesome (web fonts) + SVGs inline en redes sociales del footer. |
+| **WebP** | Capturas y fotografías. Mejor compresión que JPG sin pérdida visible. |
+| **PNG** | Logo principal (`logo.png`) por compatibilidad con favicons y manifest. Pendiente migración a SVG. |
+
+### 5.2 Herramientas utilizadas
+
+- **SVGO** (https://jakearchibald.github.io/svgomg/) para los SVG.
+- **Squoosh** (https://squoosh.app/) para imágenes JPG/PNG → WebP.
+- **ImageOptim** (en macOS) para PNGs con transparencia.
+
+### 5.3 Resultados de optimización
+
+Tabla pendiente de poblar con datos reales conforme se incorporen las capturas a la galería (`docs/design/capturas/`).
+
+### 5.4 Tecnologías implementadas
+
+#### `<picture>` con `srcset` y `sizes`
+
+Patrón previsto para la galería de capturas (B5 del plan DIW):
+
+```html
+<picture>
+  <source media="(min-width: 769px)" srcset="captura-dashboard-1200.webp" type="image/webp">
+  <img src="captura-dashboard-800.webp"
+       alt="Panel principal con tres servidores activos y métricas en vivo"
+       loading="lazy"
+       width="800" height="500">
+</picture>
+```
+
+#### `loading="lazy"`
+
+En todas las imágenes por debajo del fold (galería, secciones internas) para diferir descarga hasta que el usuario llega.
+
+### 5.5 Animaciones CSS
+
+`01-tools/_animaciones.scss` define las animaciones reutilizables. Reglas autoimpuestas:
+- Solo `transform` y `opacity` (el navegador las compone en GPU).
+- Duración 150-500ms (excepto spinner: 800ms continuo).
+- Timing function `cubic-bezier(0.16, 1, 0.3, 1)` (ease-out suave).
+- Todas se desactivan bajo `prefers-reduced-motion`.
+
+Animaciones disponibles:
+- `.animar--subir/derecha/escala` (entrada de página).
+- `.revelar` + variantes (scroll reveal con IntersectionObserver).
+- `.animar-hijos > *` (stagger de hijos).
+- `.spinner` (loading).
+- `.aparecer` (fade rápido de 0.32s, micro-interacción).
+- Keyframes locales en cada componente (`pulso-estado`, `latido`, `parpadeo-cursor`, `latido-indicador-sidebar`).
+
+---
+
+## 6. Sistema de temas
+
+### 6.1 Variables de tema
+
+Dos bloques de Custom Properties en `02-generic/_design-tokens.scss`:
+
+```scss
+:root {
+  /* tema oscuro (por defecto) */
+  --fondo-normal: hsl(30, 4.65%, 10.78%);
+  --texto-claro: hsl(40, 33.33%, 91.37%);
+  --shadow-md: 0 0.5rem 1.25rem hsla(0, 0%, 0%, 0.2);
+  /* ... */
+}
+
+.tema-claro {
+  /* overrides para tema claro */
+  --fondo-normal: hsl(40, 18%, 96%);
+  --texto-claro: hsl(30, 12%, 12%);
+  --shadow-md: 0 0.5rem 1.25rem hsla(0, 0%, 0%, 0.08);
+  /* ... */
+}
+```
+
+Sólo se sobreescriben los tokens que cambian con el tema (fondos, textos, bordes, sombras y cabecera blur). Acento amarillo, estados (verde/rojo) y tipografía se mantienen.
+
+### 6.2 Implementación del Theme Switcher
+
+`autodeploy/src/app/services/theme.service.ts` orquesta el cambio:
+
+1. Al primer arranque, lee `localStorage.tema`. Si no hay valor, llama a `matchMedia("(prefers-color-scheme: light)")` y aplica el tema del sistema.
+2. Mantiene un signal `eleccionManual` que se activa cuando el usuario pulsa el botón del header.
+3. Mientras `eleccionManual === false`, escucha el evento `change` del `MediaQueryList` y reacciona a cambios del sistema en vivo.
+4. Cuando `eleccionManual === true`, persiste en `localStorage` y prevalece sobre el sistema. Borrar `localStorage.tema` devuelve al modo automático.
+
+Tag visual en el header (`app-header`) llama a `themeService.alternarTema()`. El cambio aplica una clase `.tema-claro` al `<html>` y el reset CSS añade una transición suave de 200ms (`background-color`, `color`) que se anula bajo `prefers-reduced-motion`.
+
+### 6.3 Capturas (modo claro y oscuro)
+
+Pendiente de poblar `docs/design/capturas/` con tomas en 3 páginas representativas: landing, dashboard, billing.
+
+---
+
+## 7. Aplicación completa y despliegue
+
+### 7.1 Estado final
+
+- Frontend Angular 20 con standalone components, signals, lazy routes.
+- Backend Spring Boot 3.4 + Java 21 con record DTOs, Spring Security, Spring Data MongoDB.
+- Base de datos MongoDB 8.
+- WebSockets (Spring + xterm.js) para terminales SSH interactivas.
+- IA con OpenRouter (modelo configurable).
+- Reverse proxy nginx (contenedor + host).
+- Imagen Docker publicada en GHCR.
+- 5 idiomas (es / en / fr / de / it) con ngx-translate.
+- 68/68 tests Karma+Jasmine en frontend.
+
+### 7.2 Despliegue
+
+- URL pública: **https://autodeploy.kruhale.com**
+- Pipeline GitHub Actions: CI (build + test) → CD (build imagen + push GHCR + SSH deploy con `appleboy/ssh-action`).
+- TLS terminado por nginx-host del VPS con Let's Encrypt.
+- HSTS habilitado.
+
+### 7.3 Problemas conocidos y mejoras futuras
+
+| Área | Problema / Pendiente |
+|---|---|
+| Style Guide | Ruta `/style-guide` aún no implementada (creará todos los componentes con variantes y estados en una página). |
+| Imágenes | Generar variantes mobile/desktop de las capturas y aplicar `<picture>` + `srcset` en el sitio público. |
+| Multimedia | Crear la galería accesible (`figure` + `figcaption` + `loading="lazy"`) con capturas reales del propio AutoDeploy. |
+| WCAG | Auditoría completa con Lighthouse + WAVE + TAW y capturas antes/después en `docs/accesibilidad/`. |
+| Cuenta | `pages/cuenta/cuenta.scss` mantiene estilos `:host` por necesidades específicas; mover a global en una iteración futura. |
+| Performance | El bundle inicial supera 500 kB por 90 kB (warning de Angular CLI). Futuro: lazy-load del módulo de billing/admin. |


### PR DESCRIPTION
## Resumen

Sube el contador de componentes con `@container` de **3 a 4** (tarjeta-servidor, tarjeta-estadistica, galeria-captura, tarjeta-plan).

## Cambios

- `_seccion-precios.scss` ahora importa `@use "../01-tools/mixins" as *;`.
- `.tarjeta-plan` declara `container-type: inline-size; container-name: tarjeta-plan;`.
- `@include contenedor-pequeno` (<28rem): `padding: 1.25rem`, precio gigante a 2.25rem, periodo a 0.6875rem.
- `@include contenedor-grande` (≥48rem): `padding: 2.5rem 2.25rem`, precio gigante a 4.5rem.

## Verificación

```
@container (max-width: 28rem)
@container (min-width: 48rem)
@container galeria-captura (min-width: 24rem)
```

3 selectores únicos en `dist/.../styles-*.css`, cubriendo 4 componentes (tarjeta-servidor + tarjeta-estadistica + tarjeta-plan + galeria-captura).

## Test plan

- [x] `npm run build` → 0 errores.
- [ ] CI verde.
- [ ] Smoke test: redimensionar el grid de planes (sidebar de billing) y comprobar que el precio reduce su tamaño automáticamente.